### PR TITLE
Update Node and Composer dependencies 2024-11-12

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -183,15 +183,15 @@
         },
         {
             "name": "wpackagist-plugin/aruba-hispeed-cache",
-            "version": "2.0.17",
+            "version": "2.0.19",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/aruba-hispeed-cache/",
-                "reference": "tags/2.0.17"
+                "reference": "tags/2.0.19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/aruba-hispeed-cache.2.0.17.zip"
+                "url": "https://downloads.wordpress.org/plugin/aruba-hispeed-cache.2.0.19.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -201,15 +201,15 @@
         },
         {
             "name": "wpackagist-plugin/cookie-law-info",
-            "version": "3.2.6",
+            "version": "3.2.7",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/cookie-law-info/",
-                "reference": "tags/3.2.6"
+                "reference": "tags/3.2.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/cookie-law-info.3.2.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/cookie-law-info.3.2.7.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -219,15 +219,15 @@
         },
         {
             "name": "wpackagist-plugin/imagify",
-            "version": "2.2.2",
+            "version": "2.2.3.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/imagify/",
-                "reference": "tags/2.2.2"
+                "reference": "tags/2.2.3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/imagify.2.2.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/imagify.2.2.3.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -255,15 +255,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "23.6",
+            "version": "23.8",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/23.6"
+                "reference": "tags/23.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.23.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.23.8.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -807,12 +807,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "2133137c33fa898df70b5f879a65d83af4dbb97d"
+                "reference": "ffec7bfced474ed83c4e1b66225d37f84fdb65a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/2133137c33fa898df70b5f879a65d83af4dbb97d",
-                "reference": "2133137c33fa898df70b5f879a65d83af4dbb97d",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ffec7bfced474ed83c4e1b66225d37f84fdb65a3",
+                "reference": "ffec7bfced474ed83c4e1b66225d37f84fdb65a3",
                 "shasum": ""
             },
             "require": {
@@ -866,7 +866,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-10-05T00:46:24+00:00"
+            "time": "2024-11-08T12:53:42+00:00"
         },
         {
             "name": "wpackagist-plugin/query-monitor",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@wordpress/scripts": "^30.1",
+				"@wordpress/scripts": "^30.4",
 				"husky": "^9.1.6",
 				"lint-staged": "^15.2.10",
 				"node-sass": "^9.0.0",
-				"sass-loader": "^16.0.2"
+				"sass-loader": "^16.0.3"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -33,12 +33,13 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-			"integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.25.7",
+				"@babel/helper-validator-identifier": "^7.25.9",
+				"js-tokens": "^4.0.0",
 				"picocolors": "^1.0.0"
 			},
 			"engines": {
@@ -46,30 +47,30 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
-			"integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
+			"integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
-			"integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
+			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.24.7",
-				"@babel/helper-compilation-targets": "^7.24.7",
-				"@babel/helper-module-transforms": "^7.24.7",
-				"@babel/helpers": "^7.24.7",
-				"@babel/parser": "^7.24.7",
-				"@babel/template": "^7.24.7",
-				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7",
+				"@babel/code-frame": "^7.25.7",
+				"@babel/generator": "^7.25.7",
+				"@babel/helper-compilation-targets": "^7.25.7",
+				"@babel/helper-module-transforms": "^7.25.7",
+				"@babel/helpers": "^7.25.7",
+				"@babel/parser": "^7.25.7",
+				"@babel/template": "^7.25.7",
+				"@babel/traverse": "^7.25.7",
+				"@babel/types": "^7.25.7",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -121,12 +122,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
-			"integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
+			"integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.25.7",
+				"@babel/parser": "^7.26.2",
+				"@babel/types": "^7.26.0",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -184,14 +186,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-			"integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+			"integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.24.7",
-				"@babel/helper-validator-option": "^7.24.7",
-				"browserslist": "^4.22.2",
+				"@babel/compat-data": "^7.25.9",
+				"@babel/helper-validator-option": "^7.25.9",
+				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -348,29 +350,27 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
-			"integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+			"integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7"
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-			"integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+			"integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-module-imports": "^7.24.7",
-				"@babel/helper-simple-access": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
-				"@babel/helper-validator-identifier": "^7.24.7"
+				"@babel/helper-module-imports": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -473,27 +473,27 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-			"integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+			"integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-			"integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-			"integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+			"integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -515,111 +515,25 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
-			"integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+			"integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.24.7",
-				"@babel/types": "^7.24.7"
+				"@babel/template": "^7.25.9",
+				"@babel/types": "^7.26.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-			"integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.25.7",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.25.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
-			"integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+			"integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.25.8"
+				"@babel/types": "^7.26.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -2055,30 +1969,30 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
-			"integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+			"integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/types": "^7.25.7"
+				"@babel/code-frame": "^7.25.9",
+				"@babel/parser": "^7.25.9",
+				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
-			"integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
+			"integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/types": "^7.25.7",
+				"@babel/code-frame": "^7.25.9",
+				"@babel/generator": "^7.25.9",
+				"@babel/parser": "^7.25.9",
+				"@babel/template": "^7.25.9",
+				"@babel/types": "^7.25.9",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2087,14 +2001,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.25.8",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
-			"integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+			"integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.25.7",
-				"@babel/helper-validator-identifier": "^7.25.7",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -3252,13 +3165,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
-			"integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
+			"version": "1.48.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
+			"integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.48.0"
+				"playwright": "1.48.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4096,9 +4009,9 @@
 			}
 		},
 		"node_modules/@types/eslint-scope": {
-			"version": "3.7.3",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
-			"integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint": "*",
@@ -4106,9 +4019,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
 		},
 		"node_modules/@types/express": {
@@ -5112,27 +5025,27 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.1.0.tgz",
-			"integrity": "sha512-Jzof5xtkjUIO9ybvx3S+W/Mox/fkI+7JOwsi0jdJV2CxTBfH6A9hEykHbX3BxuLGCKJIf55OkCdap6Jif9JojQ==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.4.0.tgz",
+			"integrity": "sha512-hAX8XB8hWlxAyktT4KkBpGttRwSynmtkpLvbVKeKnj+BjABFs4TGb/HCF9hFpUK3huCAg8Ft/sjjczW+5tqspQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/core": "^7.16.0",
+				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.9.0",
-				"@wordpress/browserslist-config": "^6.9.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.9.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.9.0",
-				"@wordpress/eslint-plugin": "^21.2.0",
-				"@wordpress/jest-preset-default": "^12.9.0",
-				"@wordpress/npm-package-json-lint-config": "^5.9.0",
-				"@wordpress/postcss-plugins-preset": "^5.9.0",
-				"@wordpress/prettier-config": "^4.9.0",
-				"@wordpress/stylelint-config": "^23.1.0",
+				"@wordpress/babel-preset-default": "*",
+				"@wordpress/browserslist-config": "*",
+				"@wordpress/dependency-extraction-webpack-plugin": "*",
+				"@wordpress/e2e-test-utils-playwright": "*",
+				"@wordpress/eslint-plugin": "*",
+				"@wordpress/jest-preset-default": "*",
+				"@wordpress/npm-package-json-lint-config": "*",
+				"@wordpress/postcss-plugins-preset": "*",
+				"@wordpress/prettier-config": "*",
+				"@wordpress/stylelint-config": "*",
 				"adm-zip": "^0.5.9",
-				"babel-jest": "^29.6.2",
-				"babel-loader": "^8.2.3",
+				"babel-jest": "29.7.0",
+				"babel-loader": "9.2.1",
 				"browserslist": "^4.21.10",
 				"chalk": "^4.0.0",
 				"check-node-version": "^4.1.0",
@@ -5151,6 +5064,7 @@
 				"jest-dev-server": "^9.0.1",
 				"jest-environment-jsdom": "^29.6.2",
 				"jest-environment-node": "^29.6.2",
+				"json2php": "^0.0.9",
 				"markdownlint-cli": "^0.31.1",
 				"merge-deep": "^3.0.3",
 				"mini-css-extract-plugin": "^2.5.1",
@@ -5171,9 +5085,9 @@
 				"schema-utils": "^4.2.0",
 				"source-map-loader": "^3.0.0",
 				"stylelint": "^16.8.2",
-				"terser-webpack-plugin": "^5.3.9",
+				"terser-webpack-plugin": "^5.3.10",
 				"url-loader": "^4.1.1",
-				"webpack": "^5.88.2",
+				"webpack": "^5.95.0",
 				"webpack-bundle-analyzer": "^4.9.1",
 				"webpack-cli": "^5.1.4",
 				"webpack-dev-server": "^4.15.1"
@@ -5186,7 +5100,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.47.0",
+				"@playwright/test": "^1.48.1",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -5234,6 +5148,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/@wordpress/scripts/node_modules/json2php": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.9.tgz",
+			"integrity": "sha512-fQMYwvPsQt8hxRnCGyg1r2JVi6yL8Um0DIIawiKiMK9yhAAkcRNj5UsBWoaFvFzPpcWbgw9L6wzj+UMYA702Mw==",
 			"dev": true
 		},
 		"node_modules/@wordpress/scripts/node_modules/node-sass": {
@@ -5460,9 +5380,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-			"integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -5479,15 +5399,6 @@
 			"dependencies": {
 				"acorn": "^8.1.0",
 				"acorn-walk": "^8.0.2"
-			}
-		},
-		"node_modules/acorn-import-attributes": {
-			"version": "1.9.5",
-			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-			"dev": true,
-			"peerDependencies": {
-				"acorn": "^8"
 			}
 		},
 		"node_modules/acorn-jsx": {
@@ -6156,36 +6067,69 @@
 			}
 		},
 		"node_modules/babel-loader": {
-			"version": "8.2.5",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
-			"integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.2.1.tgz",
+			"integrity": "sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==",
 			"dev": true,
 			"dependencies": {
-				"find-cache-dir": "^3.3.1",
-				"loader-utils": "^2.0.0",
-				"make-dir": "^3.1.0",
-				"schema-utils": "^2.6.5"
+				"find-cache-dir": "^4.0.0",
+				"schema-utils": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 8.9"
+				"node": ">= 14.15.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0",
-				"webpack": ">=2"
+				"@babel/core": "^7.12.0",
+				"webpack": ">=5"
 			}
 		},
-		"node_modules/babel-loader/node_modules/schema-utils": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
-			"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+		"node_modules/babel-loader/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"dependencies": {
-				"@types/json-schema": "^7.0.5",
-				"ajv": "^6.12.4",
-				"ajv-keywords": "^3.5.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/babel-loader/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/babel-loader/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/babel-loader/node_modules/schema-utils": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+			"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
 			},
 			"engines": {
-				"node": ">= 8.9.0"
+				"node": ">= 12.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -7254,10 +7198,10 @@
 				"node": ">= 12.0.0"
 			}
 		},
-		"node_modules/commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+		"node_modules/common-path-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+			"integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
 			"dev": true
 		},
 		"node_modules/compressible": {
@@ -8583,9 +8527,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.17.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-			"integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -10238,20 +10182,116 @@
 			"dev": true
 		},
 		"node_modules/find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
+			"integrity": "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==",
 			"dev": true,
 			"dependencies": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
+				"common-path-prefix": "^3.0.0",
+				"pkg-dir": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=14.16"
 			},
 			"funding": {
-				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/find-up": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^7.1.0",
+				"path-exists": "^5.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/locate-path": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+			"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^6.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/p-limit": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^1.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/p-locate": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/path-exists": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+			"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/pkg-dir": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+			"integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-cache-dir/node_modules/yocto-queue": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+			"integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/find-file-up": {
@@ -16677,13 +16717,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
-			"integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
+			"version": "1.48.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
+			"integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.48.0"
+				"playwright-core": "1.48.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -16696,9 +16736,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
-			"integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
+			"version": "1.48.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
+			"integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
 			"dev": true,
 			"peer": true,
 			"bin": {
@@ -18624,9 +18664,9 @@
 			}
 		},
 		"node_modules/sass-loader": {
-			"version": "16.0.2",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.2.tgz",
-			"integrity": "sha512-Ll6iXZ1EYwYT19SqW4mSBb76vSSi8JgzElmzIerhEGgzB5hRjDQIWsPmuk1UrAXkR16KJHqVY0eH+5/uw9Tmfw==",
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.3.tgz",
+			"integrity": "sha512-gosNorT1RCkuCMyihv6FBRR7BMV06oKRAs+l4UMp1mlcVg9rWN6KMmUj3igjQwmYys4mDP3etEYJgiHRbgHCHA==",
 			"dev": true,
 			"dependencies": {
 				"neo-async": "^2.6.2"
@@ -20524,15 +20564,6 @@
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true
 		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -21265,21 +21296,20 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.92.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.1.tgz",
-			"integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
+			"version": "5.96.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+			"integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
 			"dev": true,
 			"dependencies": {
-				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^1.0.5",
+				"@types/eslint-scope": "^3.7.7",
+				"@types/estree": "^1.0.6",
 				"@webassemblyjs/ast": "^1.12.1",
 				"@webassemblyjs/wasm-edit": "^1.12.1",
 				"@webassemblyjs/wasm-parser": "^1.12.1",
-				"acorn": "^8.7.1",
-				"acorn-import-attributes": "^1.9.5",
-				"browserslist": "^4.21.10",
+				"acorn": "^8.14.0",
+				"browserslist": "^4.24.0",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.0",
+				"enhanced-resolve": "^5.17.1",
 				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
@@ -22201,37 +22231,38 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-			"integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.25.7",
+				"@babel/helper-validator-identifier": "^7.25.9",
+				"js-tokens": "^4.0.0",
 				"picocolors": "^1.0.0"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
-			"integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
+			"integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
-			"integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
+			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
 			"dev": true,
 			"requires": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.24.7",
-				"@babel/generator": "^7.24.7",
-				"@babel/helper-compilation-targets": "^7.24.7",
-				"@babel/helper-module-transforms": "^7.24.7",
-				"@babel/helpers": "^7.24.7",
-				"@babel/parser": "^7.24.7",
-				"@babel/template": "^7.24.7",
-				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7",
+				"@babel/code-frame": "^7.25.7",
+				"@babel/generator": "^7.25.7",
+				"@babel/helper-compilation-targets": "^7.25.7",
+				"@babel/helper-module-transforms": "^7.25.7",
+				"@babel/helpers": "^7.25.7",
+				"@babel/parser": "^7.25.7",
+				"@babel/template": "^7.25.7",
+				"@babel/traverse": "^7.25.7",
+				"@babel/types": "^7.25.7",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -22267,12 +22298,13 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
-			"integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
+			"integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.25.7",
+				"@babel/parser": "^7.26.2",
+				"@babel/types": "^7.26.0",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -22317,14 +22349,14 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-			"integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+			"integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.24.7",
-				"@babel/helper-validator-option": "^7.24.7",
-				"browserslist": "^4.22.2",
+				"@babel/compat-data": "^7.25.9",
+				"@babel/helper-validator-option": "^7.25.9",
+				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -22448,26 +22480,24 @@
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
-			"integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+			"integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7"
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-			"integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+			"integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-environment-visitor": "^7.24.7",
-				"@babel/helper-module-imports": "^7.24.7",
-				"@babel/helper-simple-access": "^7.24.7",
-				"@babel/helper-split-export-declaration": "^7.24.7",
-				"@babel/helper-validator-identifier": "^7.24.7"
+				"@babel/helper-module-imports": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -22537,21 +22567,21 @@
 			}
 		},
 		"@babel/helper-string-parser": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-			"integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+			"integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
 			"dev": true
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-			"integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-			"integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+			"integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
 			"dev": true
 		},
 		"@babel/helper-wrap-function": {
@@ -22567,92 +22597,22 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
-			"integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+			"integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.24.7",
-				"@babel/types": "^7.24.7"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-			"integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.25.7",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"@babel/template": "^7.25.9",
+				"@babel/types": "^7.26.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.25.8",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
-			"integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+			"integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.25.8"
+				"@babel/types": "^7.26.0"
 			}
 		},
 		"@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
@@ -23610,40 +23570,39 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
-			"integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+			"integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/types": "^7.25.7"
+				"@babel/code-frame": "^7.25.9",
+				"@babel/parser": "^7.25.9",
+				"@babel/types": "^7.25.9"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
-			"integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
+			"integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/types": "^7.25.7",
+				"@babel/code-frame": "^7.25.9",
+				"@babel/generator": "^7.25.9",
+				"@babel/parser": "^7.25.9",
+				"@babel/template": "^7.25.9",
+				"@babel/types": "^7.25.9",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.25.8",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
-			"integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+			"integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-string-parser": "^7.25.7",
-				"@babel/helper-validator-identifier": "^7.25.7",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9"
 			}
 		},
 		"@bcoe/v8-coverage": {
@@ -24393,13 +24352,13 @@
 			"dev": true
 		},
 		"@playwright/test": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
-			"integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
+			"version": "1.48.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
+			"integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"playwright": "1.48.0"
+				"playwright": "1.48.2"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -24991,9 +24950,9 @@
 			}
 		},
 		"@types/eslint-scope": {
-			"version": "3.7.3",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
-			"integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"dev": true,
 			"requires": {
 				"@types/eslint": "*",
@@ -25001,9 +24960,9 @@
 			}
 		},
 		"@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
 		},
 		"@types/express": {
@@ -25784,27 +25743,27 @@
 			"requires": {}
 		},
 		"@wordpress/scripts": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.1.0.tgz",
-			"integrity": "sha512-Jzof5xtkjUIO9ybvx3S+W/Mox/fkI+7JOwsi0jdJV2CxTBfH6A9hEykHbX3BxuLGCKJIf55OkCdap6Jif9JojQ==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.4.0.tgz",
+			"integrity": "sha512-hAX8XB8hWlxAyktT4KkBpGttRwSynmtkpLvbVKeKnj+BjABFs4TGb/HCF9hFpUK3huCAg8Ft/sjjczW+5tqspQ==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.16.0",
+				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.9.0",
-				"@wordpress/browserslist-config": "^6.9.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.9.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.9.0",
-				"@wordpress/eslint-plugin": "^21.2.0",
-				"@wordpress/jest-preset-default": "^12.9.0",
-				"@wordpress/npm-package-json-lint-config": "^5.9.0",
-				"@wordpress/postcss-plugins-preset": "^5.9.0",
-				"@wordpress/prettier-config": "^4.9.0",
-				"@wordpress/stylelint-config": "^23.1.0",
+				"@wordpress/babel-preset-default": "*",
+				"@wordpress/browserslist-config": "*",
+				"@wordpress/dependency-extraction-webpack-plugin": "*",
+				"@wordpress/e2e-test-utils-playwright": "*",
+				"@wordpress/eslint-plugin": "*",
+				"@wordpress/jest-preset-default": "*",
+				"@wordpress/npm-package-json-lint-config": "*",
+				"@wordpress/postcss-plugins-preset": "*",
+				"@wordpress/prettier-config": "*",
+				"@wordpress/stylelint-config": "*",
 				"adm-zip": "^0.5.9",
-				"babel-jest": "^29.6.2",
-				"babel-loader": "^8.2.3",
+				"babel-jest": "29.7.0",
+				"babel-loader": "9.2.1",
 				"browserslist": "^4.21.10",
 				"chalk": "^4.0.0",
 				"check-node-version": "^4.1.0",
@@ -25823,6 +25782,7 @@
 				"jest-dev-server": "^9.0.1",
 				"jest-environment-jsdom": "^29.6.2",
 				"jest-environment-node": "^29.6.2",
+				"json2php": "^0.0.9",
 				"markdownlint-cli": "^0.31.1",
 				"merge-deep": "^3.0.3",
 				"mini-css-extract-plugin": "^2.5.1",
@@ -25843,9 +25803,9 @@
 				"schema-utils": "^4.2.0",
 				"source-map-loader": "^3.0.0",
 				"stylelint": "^16.8.2",
-				"terser-webpack-plugin": "^5.3.9",
+				"terser-webpack-plugin": "^5.3.10",
 				"url-loader": "^4.1.1",
-				"webpack": "^5.88.2",
+				"webpack": "^5.95.0",
 				"webpack-bundle-analyzer": "^4.9.1",
 				"webpack-cli": "^5.1.4",
 				"webpack-dev-server": "^4.15.1"
@@ -25884,6 +25844,12 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				},
+				"json2php": {
+					"version": "0.0.9",
+					"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.9.tgz",
+					"integrity": "sha512-fQMYwvPsQt8hxRnCGyg1r2JVi6yL8Um0DIIawiKiMK9yhAAkcRNj5UsBWoaFvFzPpcWbgw9L6wzj+UMYA702Mw==",
 					"dev": true
 				},
 				"node-sass": {
@@ -26043,9 +26009,9 @@
 			}
 		},
 		"acorn": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-			"integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"dev": true
 		},
 		"acorn-globals": {
@@ -26057,13 +26023,6 @@
 				"acorn": "^8.1.0",
 				"acorn-walk": "^8.0.2"
 			}
-		},
-		"acorn-import-attributes": {
-			"version": "1.9.5",
-			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-			"dev": true,
-			"requires": {}
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
@@ -26545,26 +26504,52 @@
 			}
 		},
 		"babel-loader": {
-			"version": "8.2.5",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
-			"integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.2.1.tgz",
+			"integrity": "sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "^3.3.1",
-				"loader-utils": "^2.0.0",
-				"make-dir": "^3.1.0",
-				"schema-utils": "^2.6.5"
+				"find-cache-dir": "^4.0.0",
+				"schema-utils": "^4.0.0"
 			},
 			"dependencies": {
-				"schema-utils": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
-					"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+				"ajv": {
+					"version": "8.17.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 					"dev": true,
 					"requires": {
-						"@types/json-schema": "^7.0.5",
-						"ajv": "^6.12.4",
-						"ajv-keywords": "^3.5.2"
+						"fast-deep-equal": "^3.1.3",
+						"fast-uri": "^3.0.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2"
+					}
+				},
+				"ajv-keywords": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+					"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.3"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+					"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.9",
+						"ajv": "^8.9.0",
+						"ajv-formats": "^2.1.1",
+						"ajv-keywords": "^5.1.0"
 					}
 				}
 			}
@@ -27369,10 +27354,10 @@
 			"integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
 			"dev": true
 		},
-		"commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+		"common-path-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+			"integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
 			"dev": true
 		},
 		"compressible": {
@@ -28373,9 +28358,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.17.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-			"integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -29593,14 +29578,73 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
+			"integrity": "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==",
 			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
+				"common-path-prefix": "^3.0.0",
+				"pkg-dir": "^7.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+					"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^7.1.0",
+						"path-exists": "^5.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+					"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^6.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+					"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+					"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^4.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+					"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+					"integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^6.3.0"
+					}
+				},
+				"yocto-queue": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+					"integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+					"dev": true
+				}
 			}
 		},
 		"find-file-up": {
@@ -34349,20 +34393,20 @@
 			}
 		},
 		"playwright": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
-			"integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
+			"version": "1.48.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
+			"integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.48.0"
+				"playwright-core": "1.48.2"
 			}
 		},
 		"playwright-core": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
-			"integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
+			"version": "1.48.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
+			"integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
 			"dev": true,
 			"peer": true
 		},
@@ -35729,9 +35773,9 @@
 			}
 		},
 		"sass-loader": {
-			"version": "16.0.2",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.2.tgz",
-			"integrity": "sha512-Ll6iXZ1EYwYT19SqW4mSBb76vSSi8JgzElmzIerhEGgzB5hRjDQIWsPmuk1UrAXkR16KJHqVY0eH+5/uw9Tmfw==",
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.3.tgz",
+			"integrity": "sha512-gosNorT1RCkuCMyihv6FBRR7BMV06oKRAs+l4UMp1mlcVg9rWN6KMmUj3igjQwmYys4mDP3etEYJgiHRbgHCHA==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.2"
@@ -37146,12 +37190,6 @@
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true
 		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-			"dev": true
-		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -37706,21 +37744,20 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "5.92.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.1.tgz",
-			"integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
+			"version": "5.96.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+			"integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
 			"dev": true,
 			"requires": {
-				"@types/eslint-scope": "^3.7.3",
-				"@types/estree": "^1.0.5",
+				"@types/eslint-scope": "^3.7.7",
+				"@types/estree": "^1.0.6",
 				"@webassemblyjs/ast": "^1.12.1",
 				"@webassemblyjs/wasm-edit": "^1.12.1",
 				"@webassemblyjs/wasm-parser": "^1.12.1",
-				"acorn": "^8.7.1",
-				"acorn-import-attributes": "^1.9.5",
-				"browserslist": "^4.21.10",
+				"acorn": "^8.14.0",
+				"browserslist": "^4.24.0",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.0",
+				"enhanced-resolve": "^5.17.1",
 				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
 		"url": "https://github.com/colis/relicta"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "^30.1",
+		"@wordpress/scripts": "^30.4",
 		"husky": "^9.1.6",
 		"lint-staged": "^15.2.10",
 		"node-sass": "^9.0.0",
-		"sass-loader": "^16.0.2"
+		"sass-loader": "^16.0.3"
 	},
 	"engines": {
 		"node": ">=14.0.0"


### PR DESCRIPTION
This PR updates the following Composer dependencies
```
wp-coding-standards/wpcs              dev-develop 2133137 dev-develop ffec7bf
wpackagist-plugin/aruba-hispeed-cache 2.0.17              2.0.19
wpackagist-plugin/cookie-law-info     3.2.6               3.2.7
wpackagist-plugin/imagify             2.2.2               2.2.3.1
wpackagist-plugin/wordpress-seo       23.6                23.8
```

and the following Node dependencies
```
@wordpress/scripts    ^30.1  →    ^30.4
sass-loader         ^16.0.2  →  ^16.0.3
```