### PR TITLE
Update Node and Composer dependencies 2024-12-04

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 		"wpackagist-plugin/cookie-law-info": "^3.0",
 		"wpackagist-plugin/imagify": "^2.0",
 		"wpackagist-plugin/redirection": "^5.2",
-		"wpackagist-plugin/wordpress-seo": "^23.0"
+		"wpackagist-plugin/wordpress-seo": "^24.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1883abf9079f05a4727b19365e86fce4",
+    "content-hash": "a313e730c41c11bbc623f9bfa96d75a4",
     "packages": [
         {
             "name": "colis/relicta-core",
@@ -201,15 +201,15 @@
         },
         {
             "name": "wpackagist-plugin/cookie-law-info",
-            "version": "3.2.7",
+            "version": "3.2.8",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/cookie-law-info/",
-                "reference": "tags/3.2.7"
+                "reference": "tags/3.2.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/cookie-law-info.3.2.7.zip"
+                "url": "https://downloads.wordpress.org/plugin/cookie-law-info.3.2.8.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -219,15 +219,15 @@
         },
         {
             "name": "wpackagist-plugin/imagify",
-            "version": "2.2.3.1",
+            "version": "2.2.3.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/imagify/",
-                "reference": "tags/2.2.3.1"
+                "reference": "tags/2.2.3.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/imagify.2.2.3.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/imagify.2.2.3.2.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -237,15 +237,15 @@
         },
         {
             "name": "wpackagist-plugin/redirection",
-            "version": "5.5.0",
+            "version": "5.5.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/redirection/",
-                "reference": "tags/5.5.0"
+                "reference": "tags/5.5.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/redirection.5.5.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/redirection.5.5.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -255,15 +255,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "23.8",
+            "version": "24.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/23.8"
+                "reference": "tags/24.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.23.8.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.24.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -723,16 +723,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.10.3",
+            "version": "3.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c"
+                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/62d32998e820bddc40f99f8251958aed187a5c9c",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
+                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
                 "shasum": ""
             },
             "require": {
@@ -799,7 +799,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-09-18T10:38:58+00:00"
+            "time": "2024-11-16T12:02:36+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -807,12 +807,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "ffec7bfced474ed83c4e1b66225d37f84fdb65a3"
+                "reference": "9f9726a01a886b3dcced5327390470a56314aa56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ffec7bfced474ed83c4e1b66225d37f84fdb65a3",
-                "reference": "ffec7bfced474ed83c4e1b66225d37f84fdb65a3",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9f9726a01a886b3dcced5327390470a56314aa56",
+                "reference": "9f9726a01a886b3dcced5327390470a56314aa56",
                 "shasum": ""
             },
             "require": {
@@ -866,19 +866,19 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-11-08T12:53:42+00:00"
+            "time": "2024-12-02T08:21:11+00:00"
         },
         {
             "name": "wpackagist-plugin/query-monitor",
-            "version": "3.16.4",
+            "version": "3.17.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/3.16.4"
+                "reference": "tags/3.17.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.16.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.17.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@wordpress/scripts": "^30.4",
-				"husky": "^9.1.6",
+				"@wordpress/scripts": "^30.6",
+				"husky": "^9.1.7",
 				"lint-staged": "^15.2.10",
 				"node-sass": "^9.0.0",
 				"sass-loader": "^16.0.3"
@@ -5025,9 +5025,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.4.0.tgz",
-			"integrity": "sha512-hAX8XB8hWlxAyktT4KkBpGttRwSynmtkpLvbVKeKnj+BjABFs4TGb/HCF9hFpUK3huCAg8Ft/sjjczW+5tqspQ==",
+			"version": "30.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.6.0.tgz",
+			"integrity": "sha512-2i6wqCdvCcf00/vLi7twNzHUdAAOo8Uk0lqntZiBKpVrjHyLkzjmPwT3So6W/VYso5QMzEXRXYVHVKGE4wX4rg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "7.25.7",
@@ -5072,7 +5072,6 @@
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
 				"postcss": "^8.4.5",
-				"postcss-import": "^16.1.0",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
 				"puppeteer-core": "^23.1.0",
@@ -11443,9 +11442,9 @@
 			}
 		},
 		"node_modules/husky": {
-			"version": "9.1.6",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
-			"integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+			"version": "9.1.7",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+			"integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
 			"dev": true,
 			"bin": {
 				"husky": "bin.js"
@@ -16898,23 +16897,6 @@
 				"postcss": "^8.4.31"
 			}
 		},
-		"node_modules/postcss-import": {
-			"version": "16.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.0.tgz",
-			"integrity": "sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==",
-			"dev": true,
-			"dependencies": {
-				"postcss-value-parser": "^4.0.0",
-				"read-cache": "^1.0.0",
-				"resolve": "^1.1.7"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"postcss": "^8.0.0"
-			}
-		},
 		"node_modules/postcss-loader": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
@@ -17907,24 +17889,6 @@
 			"version": "0.14.2",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
 			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/read-cache": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-			"dev": true,
-			"dependencies": {
-				"pify": "^2.3.0"
-			}
-		},
-		"node_modules/read-cache/node_modules/pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -25743,9 +25707,9 @@
 			"requires": {}
 		},
 		"@wordpress/scripts": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.4.0.tgz",
-			"integrity": "sha512-hAX8XB8hWlxAyktT4KkBpGttRwSynmtkpLvbVKeKnj+BjABFs4TGb/HCF9hFpUK3huCAg8Ft/sjjczW+5tqspQ==",
+			"version": "30.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.6.0.tgz",
+			"integrity": "sha512-2i6wqCdvCcf00/vLi7twNzHUdAAOo8Uk0lqntZiBKpVrjHyLkzjmPwT3So6W/VYso5QMzEXRXYVHVKGE4wX4rg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "7.25.7",
@@ -25790,7 +25754,6 @@
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
 				"postcss": "^8.4.5",
-				"postcss-import": "^16.1.0",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
 				"puppeteer-core": "^23.1.0",
@@ -30498,9 +30461,9 @@
 			}
 		},
 		"husky": {
-			"version": "9.1.6",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
-			"integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+			"version": "9.1.7",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+			"integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
 			"dev": true
 		},
 		"iconv-lite": {
@@ -34496,17 +34459,6 @@
 			"dev": true,
 			"requires": {}
 		},
-		"postcss-import": {
-			"version": "16.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.0.tgz",
-			"integrity": "sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==",
-			"dev": true,
-			"requires": {
-				"postcss-value-parser": "^4.0.0",
-				"read-cache": "^1.0.0",
-				"resolve": "^1.1.7"
-			}
-		},
 		"postcss-loader": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
@@ -35182,23 +35134,6 @@
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
 			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
 			"dev": true
-		},
-		"read-cache": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-			"dev": true,
-			"requires": {
-				"pify": "^2.3.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-					"dev": true
-				}
-			}
 		},
 		"read-pkg": {
 			"version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
 		"url": "https://github.com/colis/relicta"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "^30.4",
-		"husky": "^9.1.6",
+		"@wordpress/scripts": "^30.6",
+		"husky": "^9.1.7",
 		"lint-staged": "^15.2.10",
 		"node-sass": "^9.0.0",
 		"sass-loader": "^16.0.3"


### PR DESCRIPTION
This PR updates the following Composer dependencies
```
squizlabs/php_codesniffer         3.10.3              3.11.1
wp-coding-standards/wpcs          dev-develop ffec7bf dev-develop 9f9726a
wpackagist-plugin/cookie-law-info 3.2.7               3.2.8
wpackagist-plugin/imagify         2.2.3.1             2.2.3.2
wpackagist-plugin/query-monitor   3.16.4              3.17.0
wpackagist-plugin/redirection     5.5.0               5.5.1
wpackagist-plugin/wordpress-seo   23.8                24.0
```

and the following Node dependencies
```
@wordpress/scripts   ^30.4  →   ^30.6
husky               ^9.1.6  →  ^9.1.7
```