### PR TITLE
Update Node and Composer dependencies 2026-03-01

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 		"wpackagist-plugin/cookie-law-info": "^3.0",
 		"wpackagist-plugin/imagify": "^2.0",
 		"wpackagist-plugin/redirection": "^5.2",
-		"wpackagist-plugin/wordpress-seo": "^26.0"
+		"wpackagist-plugin/wordpress-seo": "^27.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed7f20819ca312b38cd76da95418d94a",
+    "content-hash": "a5a73bf814893e187d00e4ff04794c32",
     "packages": [
         {
             "name": "colis/relicta-core",
@@ -183,15 +183,15 @@
         },
         {
             "name": "wpackagist-plugin/aruba-hispeed-cache",
-            "version": "3.0.1",
+            "version": "3.0.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/aruba-hispeed-cache/",
-                "reference": "tags/3.0.1"
+                "reference": "tags/3.0.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/aruba-hispeed-cache.3.0.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/aruba-hispeed-cache.3.0.6.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -201,15 +201,15 @@
         },
         {
             "name": "wpackagist-plugin/cookie-law-info",
-            "version": "3.3.6",
+            "version": "3.4.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/cookie-law-info/",
-                "reference": "tags/3.3.6"
+                "reference": "tags/3.4.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/cookie-law-info.3.3.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/cookie-law-info.3.4.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -219,15 +219,15 @@
         },
         {
             "name": "wpackagist-plugin/imagify",
-            "version": "2.2.6",
+            "version": "2.2.7",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/imagify/",
-                "reference": "tags/2.2.6"
+                "reference": "tags/2.2.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/imagify.2.2.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/imagify.2.2.7.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -237,15 +237,15 @@
         },
         {
             "name": "wpackagist-plugin/redirection",
-            "version": "5.5.2",
+            "version": "5.7.5",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/redirection/",
-                "reference": "tags/5.5.2"
+                "reference": "tags/5.7.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/redirection.5.5.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/redirection.5.7.5.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -255,15 +255,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "26.3",
+            "version": "27.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/26.3"
+                "reference": "tags/27.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.26.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.27.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -275,29 +275,29 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.2",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
                 "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
@@ -367,7 +367,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-07-17T20:45:56+00:00"
+            "time": "2025-11-11T04:32:07+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -584,27 +584,27 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.4.2",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "8e89a01c7b8fed84a12a2a7f5a23a44cdbe4f62e"
+                "reference": "b598aa890815b8df16363271b659d73280129101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/8e89a01c7b8fed84a12a2a7f5a23a44cdbe4f62e",
-                "reference": "8e89a01c7b8fed84a12a2a7f5a23a44cdbe4f62e",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
+                "reference": "b598aa890815b8df16363271b659d73280129101",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.1.2",
-                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0"
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
                 "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
@@ -662,32 +662,32 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-10-28T17:00:02+00:00"
+            "time": "2025-11-12T23:06:57+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.1.3",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "8b8e17615d04f2fc2cd46fc1d2fd888fa21b3cf9"
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/8b8e17615d04f2fc2cd46fc1d2fd888fa21b3cf9",
-                "reference": "8b8e17615d04f2fc2cd46fc1d2fd888fa21b3cf9",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.13.3 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
                 "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
@@ -755,7 +755,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-10-16T16:39:32+00:00"
+            "time": "2025-12-08T14:27:58+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -842,12 +842,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "b2e3d0fd37136d6b1426ec25eff9340ddd11ef07"
+                "reference": "c580c6c606a58606efa4bb1541d665f7cd5fd5c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b2e3d0fd37136d6b1426ec25eff9340ddd11ef07",
-                "reference": "b2e3d0fd37136d6b1426ec25eff9340ddd11ef07",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/c580c6c606a58606efa4bb1541d665f7cd5fd5c4",
+                "reference": "c580c6c606a58606efa4bb1541d665f7cd5fd5c4",
                 "shasum": ""
             },
             "require": {
@@ -856,14 +856,14 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
-                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsextra": "^1.5.0",
                 "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.0"
+                "squizlabs/php_codesniffer": "^3.13.4"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
@@ -901,19 +901,19 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-04T01:06:16+00:00"
+            "time": "2026-02-25T13:04:17+00:00"
         },
         {
             "name": "wpackagist-plugin/query-monitor",
-            "version": "3.20.0",
+            "version": "3.20.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/3.20.0"
+                "reference": "tags/3.20.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.20.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.20.2.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -932,6 +932,6 @@
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@wordpress/scripts": "^30.27",
+				"@wordpress/scripts": "^31.5",
 				"husky": "^9.1.7",
-				"lint-staged": "^16.2.6",
+				"lint-staged": "^16.3.1",
 				"node-sass": "^9.0.0",
-				"sass-loader": "^16.0.6"
+				"sass-loader": "^16.0.7"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -32,15 +32,37 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/code-frame": {
-			"version": "7.26.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.25.9",
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
 				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -85,15 +107,6 @@
 				"url": "https://opencollective.com/babel"
 			}
 		},
-		"node_modules/@babel/core/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/@babel/eslint-parser": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.7.tgz",
@@ -111,16 +124,6 @@
 			"peerDependencies": {
 				"@babel/core": "^7.11.0",
 				"eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
-			}
-		},
-		"node_modules/@babel/eslint-parser/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/generator": {
@@ -199,15 +202,6 @@
 				"yallist": "^3.0.2"
 			}
 		},
-		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -235,15 +229,6 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/@babel/helper-create-regexp-features-plugin": {
 			"version": "7.26.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz",
@@ -259,15 +244,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
@@ -1570,16 +1546,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/@babel/plugin-transform-shorthand-properties": {
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
@@ -1835,15 +1801,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/preset-env/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/@babel/preset-modules": {
 			"version": "0.1.6-no-external-plugins",
 			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -1962,49 +1919,40 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@cacheable/memoize": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@cacheable/memoize/-/memoize-2.0.3.tgz",
-			"integrity": "sha512-hl9wfQgpiydhQEIv7fkjEzTGE+tcosCXLKFDO707wYJ/78FVOlowb36djex5GdbSyeHnG62pomYLMuV/OT8Pbw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@cacheable/utils": "^2.0.3"
-			}
-		},
 		"node_modules/@cacheable/memory": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.4.tgz",
-			"integrity": "sha512-cCmJKCKlT1t7hNBI1+gFCwmKFd9I4pS3zqBeNGXTSODnpa0EeDmORHY8oEMTuozfdg3cgsVh8ojLaPYb6eC7Cg==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+			"integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cacheable/utils": "^2.2.0",
-				"@keyv/bigmap": "^1.1.0",
-				"hookified": "^1.12.2",
-				"keyv": "^5.5.3"
+				"@cacheable/utils": "^2.4.0",
+				"@keyv/bigmap": "^1.3.1",
+				"hookified": "^1.15.1",
+				"keyv": "^5.6.0"
 			}
 		},
 		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.1.0.tgz",
-			"integrity": "sha512-MX7XIUNwVRK+hjZcAbNJ0Z8DREo+Weu9vinBOjGU1thEi9F6vPhICzBbk4CCf3eEefKRz7n6TfZXwUFZTSgj8Q==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hookified": "^1.12.2"
+				"hashery": "^1.4.0",
+				"hookified": "^1.15.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"keyv": "^5.5.3"
+				"keyv": "^5.6.0"
 			}
 		},
 		"node_modules/@cacheable/memory/node_modules/keyv": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-			"integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2012,23 +1960,96 @@
 			}
 		},
 		"node_modules/@cacheable/utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.2.0.tgz",
-			"integrity": "sha512-7xaQayO3msdVcxXLYcLU5wDqJBNdQcPPPHr6mdTEIQI7N7TbtSVVTpWOTfjyhg0L6AQwQdq7miKdWtTDBoBldQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+			"integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"keyv": "^5.5.3"
+				"hashery": "^1.5.0",
+				"keyv": "^5.6.0"
 			}
 		},
 		"node_modules/@cacheable/utils/node_modules/keyv": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-			"integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
@@ -2053,6 +2074,23 @@
 			"peerDependencies": {
 				"@csstools/css-tokenizer": "^3.0.4"
 			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.0.28",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+			"integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0"
 		},
 		"node_modules/@csstools/css-tokenizer": {
 			"version": "3.0.4",
@@ -2118,6 +2156,40 @@
 				"url": "https://github.com/sponsors/JounQin"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+			"integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.1.0",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+			"integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@es-joy/jsdoccomment": {
 			"version": "0.41.0",
 			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
@@ -2134,9 +2206,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2223,9 +2295,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2481,6 +2553,7 @@
 			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
 			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jest/fake-timers": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -2489,6 +2562,228 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.2.0.tgz",
+			"integrity": "sha512-kazxw2L9IPuZpQ0mEt9lu9Z98SqR74xcagANmMBU16X0lS23yPc0+S6hGLUz8kVRlomZEs/5S/Zlpqwf5yu6OQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.2.0",
+				"@jest/fake-timers": "30.2.0",
+				"@jest/types": "30.2.0",
+				"@types/jsdom": "^21.1.7",
+				"@types/node": "*",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "30.2.0",
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-mock": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@sinonjs/fake-timers": "^13.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.2.0",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
+			"version": "0.34.48",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+			"version": "13.0.5",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/expect": {
@@ -2523,6 +2818,7 @@
 			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
 			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@sinonjs/fake-timers": "^10.0.2",
@@ -2549,6 +2845,30 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern/node_modules/jest-regex-util": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
@@ -2629,9 +2949,9 @@
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -2662,6 +2982,7 @@
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
 			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@sinclair/typebox": "^0.27.8"
 			},
@@ -2748,6 +3069,7 @@
 			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
 			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
@@ -2853,6 +3175,19 @@
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
 			"integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
 			"dev": true
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.4.3",
+				"@emnapi/runtime": "^1.4.3",
+				"@tybys/wasm-util": "^0.10.0"
+			}
 		},
 		"node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
 			"version": "5.1.1-v1",
@@ -3207,9 +3542,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-http/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3451,9 +3786,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3529,9 +3864,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
-			"integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -3852,14 +4187,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-			"integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.56.1"
+				"playwright": "1.58.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4041,9 +4376,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@sentry/core": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.46.0.tgz",
-			"integrity": "sha512-it7JMFqxVproAgEtbLgCVBYtQ9fIb+Bu0JD+cEplTN/Ukpe6GaolyYib5geZqslVxhp2sQgT+58aGvfd/k0N8Q==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
+			"integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4051,9 +4386,9 @@
 			}
 		},
 		"node_modules/@sentry/node": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.46.0.tgz",
-			"integrity": "sha512-pRLqAcd7GTGvN8gex5FtkQR5Mcol8gOy1WlyZZFq4rBbVtMbqKOQRhohwqnb+YrnmtFpj7IZ7KNDo077MvNeOQ==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.47.1.tgz",
+			"integrity": "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4087,9 +4422,9 @@
 				"@opentelemetry/sdk-trace-base": "^1.30.1",
 				"@opentelemetry/semantic-conventions": "^1.34.0",
 				"@prisma/instrumentation": "6.11.1",
-				"@sentry/core": "9.46.0",
-				"@sentry/node-core": "9.46.0",
-				"@sentry/opentelemetry": "9.46.0",
+				"@sentry/core": "9.47.1",
+				"@sentry/node-core": "9.47.1",
+				"@sentry/opentelemetry": "9.47.1",
 				"import-in-the-middle": "^1.14.2",
 				"minimatch": "^9.0.0"
 			},
@@ -4098,14 +4433,14 @@
 			}
 		},
 		"node_modules/@sentry/node-core": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.46.0.tgz",
-			"integrity": "sha512-XRVu5pqoklZeh4wqhxCLZkz/ipoKhitctgEFXX9Yh1e1BoHM2pIxT52wf+W6hHM676TFmFXW3uKBjsmRM3AjgA==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.47.1.tgz",
+			"integrity": "sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "9.46.0",
-				"@sentry/opentelemetry": "9.46.0",
+				"@sentry/core": "9.47.1",
+				"@sentry/opentelemetry": "9.47.1",
 				"import-in-the-middle": "^1.14.2"
 			},
 			"engines": {
@@ -4132,13 +4467,13 @@
 			}
 		},
 		"node_modules/@sentry/node/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -4148,13 +4483,13 @@
 			}
 		},
 		"node_modules/@sentry/opentelemetry": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.46.0.tgz",
-			"integrity": "sha512-w2zTxqrdmwRok0cXBoh+ksXdGRUHUZhlpfL/H2kfTodOL+Mk8rW72qUmfqQceXoqgbz8UyK8YgJbyt+XS5H4Qg==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
+			"integrity": "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "9.46.0"
+				"@sentry/core": "9.47.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -4189,16 +4524,18 @@
 			"dev": true
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-			"dev": true
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
 			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"type-detect": "4.0.8"
 			}
@@ -4208,6 +4545,7 @@
 			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
 			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.0"
 			}
@@ -4615,6 +4953,17 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4777,13 +5126,15 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
 			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/istanbul-lib-report": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
 			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/istanbul-lib-coverage": "*"
 			}
@@ -4793,15 +5144,17 @@
 			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
 			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
 			}
 		},
 		"node_modules/@types/jsdom": {
-			"version": "20.0.1",
-			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
-			"integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+			"version": "21.1.7",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
 				"@types/tough-cookie": "*",
@@ -4844,10 +5197,14 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.29",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
-			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
-			"dev": true
+			"version": "20.19.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+			"integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
 		},
 		"node_modules/@types/node-forge": {
 			"version": "1.3.11",
@@ -4892,6 +5249,13 @@
 				"@types/pg": "*"
 			}
 		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/qs": {
 			"version": "6.9.15",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
@@ -4903,6 +5267,27 @@
 			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
 			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
 			"dev": true
+		},
+		"node_modules/@types/react": {
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"csstype": "^3.2.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
+			}
 		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
@@ -4967,7 +5352,8 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/tedious": {
 			"version": "4.0.14",
@@ -4983,7 +5369,8 @@
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
 			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.10",
@@ -4995,10 +5382,11 @@
 			}
 		},
 		"node_modules/@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/yargs-parser": "*"
 			}
@@ -5007,7 +5395,8 @@
 			"version": "21.0.3",
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
 			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/yauzl": {
 			"version": "2.10.3",
@@ -5057,9 +5446,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -5214,9 +5603,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -5253,9 +5642,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -5302,6 +5691,275 @@
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-android-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^0.2.11"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.14.1",
@@ -5494,9 +6152,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.34.0.tgz",
-			"integrity": "sha512-AJQesBDb1LcmwlfpIVkuTu0gwkjgfVdbKG6sqmKfKkjYTac6k+ZJscZqYWgjIK2G0F0/TZwbN6u4otRq+yDAGw==",
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.40.0.tgz",
+			"integrity": "sha512-UzSwDaxsMarnlfFUmEWW2qvkJy4JupW49uH0JztFobCamQ5QCL71M75zIspIXffiZVjQMBWruR7/+5QTJklewA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5506,8 +6164,8 @@
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/browserslist-config": "^6.40.0",
+				"@wordpress/warning": "^3.40.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -5518,9 +6176,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.16.0.tgz",
+			"integrity": "sha512-g8eZCTULM9rdQMTYfp3U+bHjT6wTtyuo8BFE2PCwJmH60Lp6P4qjnaez1PDW2M3yujCPwDdQBIR8tPXrTAlC/A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5529,9 +6187,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.34.0.tgz",
-			"integrity": "sha512-pmcCkqG2jW+UUBSkX7rSZS33mcW6M0fKcJPD40TlK2cUZvECS5TDa2BC/b80PfIsT2kSw+Z9Wv+8eyX6I8HGjQ==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.40.0.tgz",
+			"integrity": "sha512-aX44MD4Kcr4LZT1YWa3VkMUUJjNfAgt7UECs/qrNGM8tC3l4/2Z4zRkJfpK3AoaXusb1J8+r5ZXWJWhxYK1JMQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5540,9 +6198,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.34.0.tgz",
-			"integrity": "sha512-lynP46WtxueExZoWzDgM02dSt/11J50Wu2jqRKCIAVsID75cPhjYS59kMAyTppa9R9s9J9ZEdqL0gqXsXr3+bw==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.40.0.tgz",
+			"integrity": "sha512-C6QZUieZoOEeZqT265EGIn95vIA1Nt6BPCOi1JyuJQ2hxOgk/cz4Vj7a31zJzCu/c1BKN3R6n78lB6nAuyZrVQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5557,14 +6215,13 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.34.0.tgz",
-			"integrity": "sha512-CpbjtXGxiNDjRrVx3Foo4CG2aSpmiQIjEHxLj+ItKXmg9JsDr/1iYEBraOA12LX8tUaHaEll3ykByJebMR1OdA==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.40.0.tgz",
+			"integrity": "sha512-7EMx/5R0l9mlR4s01I06x8bw7qq30VlU98T/tvYJa+ycFQK3oetkoPyiNfki2Y2SILQGjI3Mu4MSV1NPCa/mEw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"change-case": "^4.1.2",
-				"form-data": "^4.0.0",
 				"get-port": "^5.1.1",
 				"lighthouse": "^12.2.2",
 				"mime": "^3.0.0",
@@ -5575,23 +6232,67 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": ">=1"
+				"@playwright/test": ">=1",
+				"@types/node": "^20.17.10"
+			}
+		},
+		"node_modules/@wordpress/element": {
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.40.0.tgz",
+			"integrity": "sha512-OhU8B2xEGg7c41rh/VRiJLOz6TnM/r5r8sraAg5ISc2bF7s2oAFqLwvlR0/U6ervyYwbK644osWZGQxFyL3huA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.40.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/element/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/escape-html": {
+			"version": "3.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.40.0.tgz",
+			"integrity": "sha512-DD6xWVbnw4fGGgO6DFDTJiLj52om0OG4cYHLz7ZhuipmOlEUGljPYOcrj8uxtlh5EFrqHCIPkOya+qQXUHUSBw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "22.20.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.20.0.tgz",
-			"integrity": "sha512-mZuEmBLLAOT6koBsXMrFMHQskKs+p+nu1Z/Y/4u1FldRlShdbKSXZG2p9qV3SVnXdSAEa5Cr32kOvkZGacEO/Q==",
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.2.0.tgz",
+			"integrity": "sha512-FBVWV+wZ1vN6fpSZVI8gMOJ8M1q69Lp1jMUzbH46lE+ICKnQDUeX6FkN/dZiG6rOSbHau+qEGbuPwTDe2D3quQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.34.0",
-				"@wordpress/prettier-config": "^4.34.0",
+				"@wordpress/babel-preset-default": "^8.40.0",
+				"@wordpress/prettier-config": "^4.40.0",
+				"@wordpress/theme": "^0.7.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
+				"eslint-import-resolver-typescript": "^4.4.4",
 				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^27.4.3",
 				"eslint-plugin-jsdoc": "^46.4.6",
@@ -5652,13 +6353,14 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.34.0.tgz",
-			"integrity": "sha512-CovQ/aJXMjWYrvtWzY+9+fkUXi6boVtp0t679AX3BYLtLiQTzLfrvDOb6H5jWyNzXmnHC6OJqRV+baw4qVyumg==",
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.40.0.tgz",
+			"integrity": "sha512-H7j9Afosm0TvppBjQmXxErUBdWIT0u1mX+toH1liafp0gpxzowYMbv1MAASgAEzPrbL/U0P68GIW3PQXQFO4xg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"jest-matcher-utils": "^29.6.2"
+				"jest-matcher-utils": "^29.6.2",
+				"jest-mock": "^29.6.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -5669,13 +6371,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.34.0.tgz",
-			"integrity": "sha512-Pxs4gnjtf6L/gde7rCdG9wjymCKPj8VjBWdVGOtvGC8FfXNPbKioI+AIqfwCquXJs2xCyDrGei3QfLQtvQ42/g==",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.40.0.tgz",
+			"integrity": "sha512-JkH6Hsesy6cyH+encol7jvQyMtFQYLZyb/VpUrZAfUfymOh7VtSqLSGVyxvw64OLcWKE+cE/xkApvvGFBHzG4w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.34.0",
+				"@wordpress/jest-console": "^8.40.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -5688,9 +6390,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.34.0.tgz",
-			"integrity": "sha512-kLGKSxs/vDo+np++TmIpw8thebL1pCBDMdHOjweS8iwlXq2ZevXXIebG1CUk4td8cMoKW1byobtwsz2MwaEAig==",
+			"version": "5.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.40.0.tgz",
+			"integrity": "sha512-fxIya56Bf+LTnDR07RfAM5VfITl7uQm9kJkY4nUYNRC6xPj5cCLLsIh0x5UWXmYQxTTaSreMKYxDPe4UN7tATA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5702,13 +6404,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.34.0.tgz",
-			"integrity": "sha512-TP1hsALuEhNRyCGw0YI8AYB1Lq8gFJ+X7etLpjtKlY+0zyiTb+fMrZuQRnYXzwjGhN9Ni9CB1l5U0YhJ8z3VqQ==",
+			"version": "5.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.40.0.tgz",
+			"integrity": "sha512-t8zryWpd6sLUVWbFLkRW9637Nmvx4Odnyu9jQCV5yfLXRubD37x/PVRVx7tUw9SpbbrPzKB4DqpNOF+dTHaICg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.10.0",
+				"@wordpress/base-styles": "^6.16.0",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			},
@@ -5721,9 +6423,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.34.0.tgz",
-			"integrity": "sha512-vrcjpVegYSwTSC8JfcE/qmmv1lsqDDhKvLqT8rMhW4DiogH8sVThJ1w5o2qOELXON2ArqfAxW8+DVmHsTPCUzQ==",
+			"version": "4.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.40.0.tgz",
+			"integrity": "sha512-6JqPLZtoO1OnZJMVrWy+wwoCrJKD1VZnfNMLvNhhRoY7VypBXk189iyWj26JbOhBfFqIcVQNLNMTt9uTZDNujA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5734,26 +6436,37 @@
 				"prettier": ">=3"
 			}
 		},
+		"node_modules/@wordpress/private-apis": {
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.40.0.tgz",
+			"integrity": "sha512-68cwZKVq8Xy8GBzKoDRuV4b3pQ4nJFItY689HXp+poc0XXrnAeC4ZhjeSgS1qGRpFo6RVvLjjcaZsN2OrSSMvQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/scripts": {
-			"version": "30.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.27.0.tgz",
-			"integrity": "sha512-gXGptazCxAaR7g8kcN5joj7B5fCm0VeBHOmnDBs2dbQ4W4F3tfzdg6CTEj8LonF9bWQXlSy3ku8EqWCdkSG9Xw==",
+			"version": "31.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.5.0.tgz",
+			"integrity": "sha512-7OS5bpHtnuagG8k9q9BdilHjhQ0MLhY0ypDgnRom5WlgPBshM/SUaF9bQLDnSDeasiD/bIgaDmoxWkfVZ4qSPQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.34.0",
-				"@wordpress/browserslist-config": "^6.34.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.34.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.34.0",
-				"@wordpress/eslint-plugin": "^22.20.0",
-				"@wordpress/jest-preset-default": "^12.34.0",
-				"@wordpress/npm-package-json-lint-config": "^5.34.0",
-				"@wordpress/postcss-plugins-preset": "^5.34.0",
-				"@wordpress/prettier-config": "^4.34.0",
-				"@wordpress/stylelint-config": "^23.26.0",
+				"@wordpress/babel-preset-default": "^8.40.0",
+				"@wordpress/browserslist-config": "^6.40.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.40.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.40.0",
+				"@wordpress/eslint-plugin": "^24.2.0",
+				"@wordpress/jest-preset-default": "^12.40.0",
+				"@wordpress/npm-package-json-lint-config": "^5.40.0",
+				"@wordpress/postcss-plugins-preset": "^5.40.0",
+				"@wordpress/prettier-config": "^4.40.0",
+				"@wordpress/stylelint-config": "^23.32.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -5766,13 +6479,13 @@
 				"cssnano": "^6.0.1",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^8.3.0",
+				"eslint": "^8.57.1",
 				"expect-puppeteer": "^4.4.0",
 				"fast-glob": "^3.2.7",
 				"filenamify": "^4.2.0",
 				"jest": "^29.6.2",
 				"jest-dev-server": "^10.1.4",
-				"jest-environment-jsdom": "^29.6.2",
+				"jest-environment-jsdom": "^30.2.0",
 				"jest-environment-node": "^29.6.2",
 				"json2php": "^0.0.9",
 				"markdownlint-cli": "^0.31.1",
@@ -5809,7 +6522,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.56.1",
+				"@playwright/test": "^1.58.2",
 				"@wordpress/env": "^10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
@@ -5880,13 +6593,14 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.26.0.tgz",
-			"integrity": "sha512-sLuvZjkX7gSeemthpZMHHD0MUuv86hp90eyMhIl2Zv3qARpGM6er8YIDtBbhqfIIWcrrfNQcXuR3G2DvL/CfwQ==",
+			"version": "23.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.32.0.tgz",
+			"integrity": "sha512-CvkKISBezOyzq6yc3+9ZnX0ar2qv3LGB1T8EcawCcwpESyVdfGu8vP7VZMKI8jDmsl2fUXXzt5nDScpXctY17Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
+				"@wordpress/theme": "^0.7.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
@@ -5899,10 +6613,37 @@
 				"stylelint-scss": "^6.4.0"
 			}
 		},
+		"node_modules/@wordpress/theme": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.7.0.tgz",
+			"integrity": "sha512-ULwLCSKYraIsv83bVH+Hm5pGFen6/0/8xOXQwxMdxeU+8kSm0cTKlpQPNvJGCmAeQb2OgFcowB/8wrUdyqW8UQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.40.0",
+				"@wordpress/private-apis": "^1.40.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.34.0.tgz",
-			"integrity": "sha512-WemuVXjaekzCDsWbDPj/RZSy44mIjPIy35DaoJgfLcgkXMH2GRBRSomhZMkWyGatD39vdXm0nqe95LsLDqrwCg==",
+			"version": "3.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.40.0.tgz",
+			"integrity": "sha512-0l3OFa1Z+UdhWRRHX9JWWKofo7Lbi2MqOFzzzn0MC26HOyfieQycjLVLNVNXaaodIKUhap6uDQq+JXbbHm881A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5957,16 +6698,6 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/acorn-globals": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
-			"integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^8.1.0",
-				"acorn-walk": "^8.0.2"
 			}
 		},
 		"node_modules/acorn-import-attributes": {
@@ -6503,9 +7234,9 @@
 			"dev": true
 		},
 		"node_modules/atomically": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.0.tgz",
-			"integrity": "sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+			"integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6514,9 +7245,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.21",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-			"integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+			"version": "10.4.27",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+			"integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
 			"dev": true,
 			"funding": [
 				{
@@ -6534,10 +7265,9 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.24.4",
-				"caniuse-lite": "^1.0.30001702",
-				"fraction.js": "^4.3.7",
-				"normalize-range": "^0.1.2",
+				"browserslist": "^4.28.1",
+				"caniuse-lite": "^1.0.30001774",
+				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -6568,9 +7298,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-			"integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+			"integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -6742,15 +7472,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-			}
-		},
-		"node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
@@ -6926,6 +7647,19 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+			"integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
@@ -7068,9 +7802,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
 			"dev": true,
 			"funding": [
 				{
@@ -7088,10 +7822,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001688",
-				"electron-to-chromium": "^1.5.73",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.1"
+				"baseline-browser-mapping": "^2.9.0",
+				"caniuse-lite": "^1.0.30001759",
+				"electron-to-chromium": "^1.5.263",
+				"node-releases": "^2.0.27",
+				"update-browserslist-db": "^1.2.0"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -7236,24 +7971,23 @@
 			"dev": true
 		},
 		"node_modules/cacheable": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.1.1.tgz",
-			"integrity": "sha512-LmF4AXiSNdiRbI2UjH8pAp9NIXxeQsTotpEaegPiDcnN0YPygDJDV3l/Urc0mL72JWdATEorKqIHEx55nDlONg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
+			"integrity": "sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cacheable/memoize": "^2.0.3",
-				"@cacheable/memory": "^2.0.3",
-				"@cacheable/utils": "^2.1.0",
-				"hookified": "^1.12.2",
-				"keyv": "^5.5.3",
-				"qified": "^0.5.0"
+				"@cacheable/memory": "^2.0.8",
+				"@cacheable/utils": "^2.4.0",
+				"hookified": "^1.15.0",
+				"keyv": "^5.6.0",
+				"qified": "^0.6.0"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-			"integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7381,9 +8115,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001713",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
-			"integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
+			"version": "1.0.30001775",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001775.tgz",
+			"integrity": "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -7594,6 +8328,7 @@
 					"url": "https://github.com/sponsors/sibiraj-s"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -7762,6 +8497,17 @@
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
+		},
+		"node_modules/colorjs.io": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/color"
+			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -8072,9 +8818,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.46.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
-			"integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -8185,13 +8931,13 @@
 			}
 		},
 		"node_modules/css-functions-list": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-			"integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+			"integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12 || >=16"
+				"node": ">=12"
 			}
 		},
 		"node_modules/css-loader": {
@@ -8415,29 +9161,26 @@
 			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
 			"dev": true
 		},
-		"node_modules/cssom": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-			"dev": true
-		},
 		"node_modules/cssstyle": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"cssom": "~0.3.6"
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			}
 		},
-		"node_modules/cssstyle/node_modules/cssom": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-			"dev": true
+		"node_modules/csstype": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cwd": {
 			"version": "0.10.0",
@@ -8470,17 +9213,17 @@
 			}
 		},
 		"node_modules/data-urls": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-			"integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"abab": "^2.0.6",
-				"whatwg-mimetype": "^3.0.0",
-				"whatwg-url": "^11.0.0"
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/data-view-buffer": {
@@ -8599,15 +9342,16 @@
 			}
 		},
 		"node_modules/decimal.js": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-			"dev": true
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/dedent": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-			"integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
+			"integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -8858,19 +9602,6 @@
 				}
 			]
 		},
-		"node_modules/domexception": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-			"integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-			"deprecated": "Use your platform's native DOMException instead",
-			"dev": true,
-			"dependencies": {
-				"webidl-conversions": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/domhandler": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
@@ -8966,9 +9697,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.136",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz",
-			"integrity": "sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==",
+			"version": "1.5.302",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+			"integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -9128,9 +9859,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-			"integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+			"version": "1.24.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+			"integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9215,27 +9946,27 @@
 			}
 		},
 		"node_modules/es-iterator-helpers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
-			"integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
+			"integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
+				"call-bound": "^1.0.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.6",
+				"es-abstract": "^1.24.1",
 				"es-errors": "^1.3.0",
-				"es-set-tostringtag": "^2.0.3",
+				"es-set-tostringtag": "^2.1.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.6",
+				"get-intrinsic": "^1.3.0",
 				"globalthis": "^1.0.4",
 				"gopd": "^1.2.0",
 				"has-property-descriptors": "^1.0.2",
 				"has-proto": "^1.2.0",
 				"has-symbols": "^1.1.0",
 				"internal-slot": "^1.1.0",
-				"iterator.prototype": "^1.1.4",
+				"iterator.prototype": "^1.1.5",
 				"safe-array-concat": "^1.1.3"
 			},
 			"engines": {
@@ -9425,6 +10156,31 @@
 				"eslint": ">=7.0.0"
 			}
 		},
+		"node_modules/eslint-import-context": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+			"integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-tsconfig": "^4.10.1",
+				"stable-hash-x": "^0.2.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-import-context"
+			},
+			"peerDependencies": {
+				"unrs-resolver": "^1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"unrs-resolver": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/eslint-import-resolver-node": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -9445,6 +10201,41 @@
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-import-resolver-typescript": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+			"integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"debug": "^4.4.1",
+				"eslint-import-context": "^0.1.8",
+				"get-tsconfig": "^4.10.1",
+				"is-bun-module": "^2.0.0",
+				"stable-hash-x": "^0.2.0",
+				"tinyglobby": "^0.2.14",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^16.17.0 || >=18.6.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-import-resolver-typescript"
+			},
+			"peerDependencies": {
+				"eslint": "*",
+				"eslint-plugin-import": "*",
+				"eslint-plugin-import-x": "*"
+			},
+			"peerDependenciesMeta": {
+				"eslint-plugin-import": {
+					"optional": true
+				},
+				"eslint-plugin-import-x": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/eslint-module-utils": {
@@ -9530,16 +10321,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
@@ -9687,9 +10468,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -9724,9 +10505,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -9794,14 +10575,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.5.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-			"integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+			"version": "5.5.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.11.7"
+				"prettier-linter-helpers": "^1.0.1",
+				"synckit": "^0.11.12"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -9884,31 +10665,27 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/resolve": {
-			"version": "2.0.0-next.5",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+			"version": "2.0.0-next.6",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+			"integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.13.0",
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
+				"node-exports-info": "^1.6.0",
+				"object-keys": "^1.1.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
 			"bin": {
 				"resolve": "bin/resolve"
 			},
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/eslint-plugin-react/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -10014,9 +10791,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10116,9 +10893,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -10873,16 +11650,16 @@
 			"license": "MIT"
 		},
 		"node_modules/fraction.js": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-			"integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+			"integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
 			},
 			"funding": {
-				"type": "patreon",
+				"type": "github",
 				"url": "https://github.com/sponsors/rawify"
 			}
 		},
@@ -11136,6 +11913,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/get-uri": {
@@ -11471,6 +12261,19 @@
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 			"dev": true
 		},
+		"node_modules/hashery": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+			"integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hookified": "^1.14.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -11507,9 +12310,9 @@
 			}
 		},
 		"node_modules/hookified": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.2.tgz",
-			"integrity": "sha512-aokUX1VdTpI0DUsndvW+OiwmBpKCu/NgRsSSkuSY0zq8PY6Q6a+lmOfAFDXAAOtBqJELvcWY9L1EVtzjbQcMdg==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+			"integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -11580,15 +12383,16 @@
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-			"integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"whatwg-encoding": "^2.0.0"
+				"whatwg-encoding": "^3.1.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/html-entities": {
@@ -12163,6 +12967,29 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-bun-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+			"integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.7.1"
+			}
+		},
+		"node_modules/is-bun-module/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -12426,7 +13253,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
@@ -12948,30 +13776,222 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
-			"integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.2.0.tgz",
+			"integrity": "sha512-zbBTiqr2Vl78pKp/laGBREYzbZx9ZtqPjOK4++lL4BNDhxRnahg51HtoDrk9/VjIy9IthNEWdKVd7H5bqBhiWQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/jsdom": "^20.0.0",
+				"@jest/environment": "30.2.0",
+				"@jest/environment-jsdom-abstract": "30.2.0",
+				"@types/jsdom": "^21.1.7",
 				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jsdom": "^20.0.0"
+				"jsdom": "^26.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"canvas": "^2.5.0"
+				"canvas": "^3.0.0"
 			},
 			"peerDependenciesMeta": {
 				"canvas": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "30.2.0",
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-mock": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@sinonjs/fake-timers": "^13.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.2.0",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
+			"version": "0.34.48",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
+			"version": "13.0.5",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.2.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"micromatch": "^4.0.8",
+				"pretty-format": "30.2.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"jest-util": "30.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/jest-util": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.2.0",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-node": {
@@ -13095,6 +14115,7 @@
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
 			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.12.13",
 				"@jest/types": "^29.6.3",
@@ -13115,6 +14136,7 @@
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
 			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@types/node": "*",
@@ -13319,9 +14341,9 @@
 			}
 		},
 		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -13336,6 +14358,7 @@
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
 			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jest/types": "^29.6.3",
 				"@types/node": "*",
@@ -13458,9 +14481,9 @@
 			"dev": true
 		},
 		"node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13482,43 +14505,38 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-			"integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"abab": "^2.0.6",
-				"acorn": "^8.8.1",
-				"acorn-globals": "^7.0.0",
-				"cssom": "^0.5.0",
-				"cssstyle": "^2.3.0",
-				"data-urls": "^3.0.2",
-				"decimal.js": "^10.4.2",
-				"domexception": "^4.0.0",
-				"escodegen": "^2.0.0",
-				"form-data": "^4.0.0",
-				"html-encoding-sniffer": "^3.0.0",
-				"http-proxy-agent": "^5.0.0",
-				"https-proxy-agent": "^5.0.1",
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
 				"is-potential-custom-element-name": "^1.0.1",
-				"nwsapi": "^2.2.2",
-				"parse5": "^7.1.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^4.1.2",
-				"w3c-xmlserializer": "^4.0.0",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
 				"webidl-conversions": "^7.0.0",
-				"whatwg-encoding": "^2.0.0",
-				"whatwg-mimetype": "^3.0.0",
-				"whatwg-url": "^11.0.0",
-				"ws": "^8.11.0",
-				"xml-name-validator": "^4.0.0"
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"canvas": "^2.5.0"
+				"canvas": "^3.0.0"
 			},
 			"peerDependenciesMeta": {
 				"canvas": {
@@ -13526,27 +14544,42 @@
 				}
 			}
 		},
-		"node_modules/jsdom/node_modules/@tootallnate/once": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+		"node_modules/jsdom/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/jsdom/node_modules/http-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@tootallnate/once": "2",
-				"agent-base": "6",
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/jsdom/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
 				"debug": "4"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/jsesc": {
@@ -13808,9 +14841,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-			"version": "2.10.13",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.13.tgz",
-			"integrity": "sha512-a9Ruw3j3qlnB5a/zHRTkruppynxqaeE4H9WNj5eYGRWqw0ZauZ23f4W2ARf3hghF5doozyD+CRtt7XSYuYRI/Q==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+			"integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -13818,7 +14851,7 @@
 				"extract-zip": "^2.0.1",
 				"progress": "^2.0.3",
 				"proxy-agent": "^6.5.0",
-				"semver": "^7.7.3",
+				"semver": "^7.7.4",
 				"tar-fs": "^3.1.1",
 				"yargs": "^17.7.2"
 			},
@@ -13830,28 +14863,28 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.28.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.28.0.tgz",
-			"integrity": "sha512-QpAqaYgeZHF5/xAZ4jAOzsU+l0Ed4EJoWkRdfw8rNqmSN7itcdYeCJaSPQ0s5Pyn/eGNC4xNevxbgY+5bzNllw==",
+			"version": "24.37.5",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.5.tgz",
+			"integrity": "sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.10.13",
-				"chromium-bidi": "10.5.1",
+				"@puppeteer/browsers": "2.13.0",
+				"chromium-bidi": "14.0.0",
 				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1521046",
+				"devtools-protocol": "0.0.1566079",
 				"typed-query-selector": "^2.12.0",
-				"webdriver-bidi-protocol": "0.3.8",
-				"ws": "^8.18.3"
+				"webdriver-bidi-protocol": "0.4.1",
+				"ws": "^8.19.0"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "10.5.1",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.5.1.tgz",
-			"integrity": "sha512-rlj6OyhKhVTnk4aENcUme3Jl9h+cq4oXu4AzBcvr8RMmT6BR4a3zSNT9dbIfXr9/BS6ibzRyDhowuw4n2GgzsQ==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+			"integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -13863,16 +14896,16 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1521046",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
-			"integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
+			"version": "0.0.1566079",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
+			"integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13892,9 +14925,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -13974,19 +15007,18 @@
 			}
 		},
 		"node_modules/lint-staged": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.6.tgz",
-			"integrity": "sha512-s1gphtDbV4bmW1eylXpVMk2u7is7YsrLl8hzrtvC70h4ByhcMLZFY01Fx05ZUDNuv1H8HO4E+e2zgejV1jVwNw==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.1.tgz",
+			"integrity": "sha512-bqvvquXzFBAlSbluugR4KXAe4XnO/QZcKVszpkBtqLWa2KEiVy8n6Xp38OeUbv/gOJOX4Vo9u5pFt/ADvbm42Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"commander": "^14.0.1",
+				"commander": "^14.0.3",
 				"listr2": "^9.0.5",
 				"micromatch": "^4.0.8",
-				"nano-spawn": "^2.0.0",
-				"pidtree": "^0.6.0",
 				"string-argv": "^0.3.2",
-				"yaml": "^2.8.1"
+				"tinyexec": "^1.0.2",
+				"yaml": "^2.8.2"
 			},
 			"bin": {
 				"lint-staged": "bin/lint-staged.js"
@@ -13999,9 +15031,9 @@
 			}
 		},
 		"node_modules/lint-staged/node_modules/commander": {
-			"version": "14.0.2",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-			"integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -14009,9 +15041,9 @@
 			}
 		},
 		"node_modules/lint-staged/node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -14019,6 +15051,9 @@
 			},
 			"engines": {
 				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/listr2": {
@@ -14166,9 +15201,9 @@
 			"dev": true
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -14410,9 +15445,9 @@
 			}
 		},
 		"node_modules/make-dir/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -14666,6 +15701,13 @@
 			"engines": {
 				"node": ">= 4.0.0"
 			}
+		},
+		"node_modules/memize": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/meow": {
 			"version": "9.0.0",
@@ -15141,19 +16183,6 @@
 			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
 			"dev": true
 		},
-		"node_modules/nano-spawn": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-			"integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.17"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-			}
-		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -15171,6 +16200,22 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/napi-postinstall": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"napi-postinstall": "lib/cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/napi-postinstall"
 			}
 		},
 		"node_modules/natural-compare": {
@@ -15220,6 +16265,25 @@
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
 			"dev": true
+		},
+		"node_modules/node-exports-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array.prototype.flatmap": "^1.3.3",
+				"es-errors": "^1.3.0",
+				"object.entries": "^1.1.9",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
@@ -15371,9 +16435,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"version": "2.0.27",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -15748,16 +16812,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/normalize-range": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/npm-bundled": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -15854,9 +16908,9 @@
 			}
 		},
 		"node_modules/npm-package-json-lint/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15874,9 +16928,9 @@
 			"license": "MIT"
 		},
 		"node_modules/npm-package-json-lint/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -15942,10 +16996,11 @@
 			}
 		},
 		"node_modules/nwsapi": {
-			"version": "2.2.10",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
-			"integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==",
-			"dev": true
+			"version": "2.2.23",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -16416,15 +17471,29 @@
 			}
 		},
 		"node_modules/parse5": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"entities": "^4.4.0"
+				"entities": "^6.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/parseurl": {
@@ -16524,9 +17593,9 @@
 			}
 		},
 		"node_modules/pg-protocol": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.12.0.tgz",
+			"integrity": "sha512-uOANXNRACNdElMXJ0tPz6RBM0XQ61nONGAwlt8da5zs/iUOOCLBQOHSXnrC6fMsvtjxbOJrZZl5IScGv+7mpbg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16565,18 +17634,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/pidtree": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-			"integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-			"dev": true,
-			"bin": {
-				"pidtree": "bin/pidtree.js"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -16610,14 +17667,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-			"integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.56.1"
+				"playwright-core": "1.58.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -16630,9 +17687,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-			"integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -17335,9 +18392,9 @@
 			}
 		},
 		"node_modules/postgres-bytea": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-			"integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+			"integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -17395,9 +18452,9 @@
 			}
 		},
 		"node_modules/prettier-linter-helpers": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+			"integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -17412,6 +18469,7 @@
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
 			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jest/schemas": "^29.6.3",
 				"ansi-styles": "^5.0.0",
@@ -17426,6 +18484,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -17601,12 +18660,6 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
-		"node_modules/psl": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-			"dev": true
-		},
 		"node_modules/pump": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -17619,10 +18672,11 @@
 			}
 		},
 		"node_modules/punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -17670,13 +18724,13 @@
 			"license": "MIT"
 		},
 		"node_modules/qified": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/qified/-/qified-0.5.1.tgz",
-			"integrity": "sha512-+BtFN3dCP+IaFA6IYNOu/f/uK1B8xD2QWyOeCse0rjtAebBmkzgd2d1OAXi3ikAzJMIBSdzZDNZ3wZKEUDQs5w==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+			"integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hookified": "^1.12.2"
+				"hookified": "^1.14.0"
 			},
 			"engines": {
 				"node": ">=20"
@@ -17696,12 +18750,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/querystringify": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-			"dev": true
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -17805,7 +18853,6 @@
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -17818,7 +18865,8 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/react-refresh": {
 			"version": "0.14.2",
@@ -18192,6 +19240,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/resolve.exports": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -18300,6 +19358,13 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
+		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/rtlcss": {
 			"version": "4.3.0",
@@ -18493,9 +19558,9 @@
 			}
 		},
 		"node_modules/sass-loader": {
-			"version": "16.0.6",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.6.tgz",
-			"integrity": "sha512-sglGzId5gmlfxNs4gK2U3h7HlVRfx278YK6Ono5lwzuvi1jxig80YiuHkaDBVsYIKFhx8wN7XSCI0M2IDS/3qA==",
+			"version": "16.0.7",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+			"integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18509,7 +19574,7 @@
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"@rspack/core": "0.x || 1.x",
+				"@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
 				"node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
 				"sass": "^1.3.0",
 				"sass-embedded": "*",
@@ -18566,6 +19631,7 @@
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
 			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"xmlchars": "^2.2.0"
 			},
@@ -18579,7 +19645,6 @@
 			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			}
@@ -18641,10 +19706,11 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -19057,6 +20123,7 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -19320,11 +20387,22 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/stable-hash-x": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+			"integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
 			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"escape-string-regexp": "^2.0.0"
 			},
@@ -19337,6 +20415,7 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
 			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -19745,9 +20824,9 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "16.25.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.25.0.tgz",
-			"integrity": "sha512-Li0avYWV4nfv1zPbdnxLYBGq4z8DVZxbRgx4Kn6V+Uftz1rMoF1qiEI3oL4kgWqyYgCgs7gT5maHNZ82Gk03vQ==",
+			"version": "16.26.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
 			"dev": true,
 			"funding": [
 				{
@@ -19762,6 +20841,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
 				"@csstools/css-tokenizer": "^3.0.4",
 				"@csstools/media-query-list-parser": "^4.0.3",
 				"@csstools/selector-specificity": "^5.0.0",
@@ -19774,7 +20854,7 @@
 				"debug": "^4.4.3",
 				"fast-glob": "^3.3.3",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^10.1.4",
+				"file-entry-cache": "^11.1.1",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
@@ -19855,26 +20935,26 @@
 			}
 		},
 		"node_modules/stylelint-scss": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
-			"integrity": "sha512-UJUfBFIvXfly8WKIgmqfmkGKPilKB4L5j38JfsDd+OCg2GBdU0vGUV08Uw82tsRZzd4TbsUURVVNGeOhJVF7pA==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
+			"integrity": "sha512-ZKmHMZolxeuYsnB+PCYrTpFce0/QWX9i9gh0hPXzp73WjuIMqUpzdQaBCrKoLWh6XtCFSaNDErkMPqdjy1/8aA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-tree": "^3.0.1",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.36.0",
-				"mdn-data": "^2.21.0",
+				"known-css-properties": "^0.37.0",
+				"mdn-data": "^2.25.0",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.6",
-				"postcss-selector-parser": "^7.1.0",
+				"postcss-selector-parser": "^7.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
 				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^16.0.2"
+				"stylelint": "^16.8.2"
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/css-tree": {
@@ -19908,24 +20988,17 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/stylelint-scss/node_modules/known-css-properties": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
-			"integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.25.0.tgz",
-			"integrity": "sha512-T2LPsjgUE/tgMmRXREVmwsux89DwWfNjiynOeXuLd2mX6jphGQ2YE3Ukz7LQ2VOFKiVZU/Ee1GqzHiipZCjymw==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20046,25 +21119,25 @@
 			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "10.1.4",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
-			"integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^6.1.13"
+				"flat-cache": "^6.1.20"
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.18",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.18.tgz",
-			"integrity": "sha512-JUPnFgHMuAVmLmoH9/zoZ6RHOt5n9NlUw/sDXsTbROJ2SFoS2DS4s+swAV6UTeTbGH/CAsZIE6M8TaG/3jVxgQ==",
+			"version": "6.1.20",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+			"integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cacheable": "^2.1.0",
+				"cacheable": "^2.3.2",
 				"flatted": "^3.3.3",
-				"hookified": "^1.12.0"
+				"hookified": "^1.15.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/global-modules": {
@@ -20126,9 +21199,9 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20169,9 +21242,9 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20328,12 +21401,13 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/synckit": {
-			"version": "0.11.11",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-			"integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20364,9 +21438,9 @@
 			}
 		},
 		"node_modules/table/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20616,22 +21690,100 @@
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
 		},
+		"node_modules/tinyexec": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
 		"node_modules/tldts-core": {
-			"version": "7.0.17",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.17.tgz",
-			"integrity": "sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==",
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+			"integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tldts-icann": {
-			"version": "7.0.17",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.17.tgz",
-			"integrity": "sha512-up4oFDoumyz2RscRxoYRxf+2OvIKUHjh7rUvuGWI0PZ/47k35sadoi2JyKR0AIfTw09qcfix8bUxXFQhY1QZIQ==",
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.23.tgz",
+			"integrity": "sha512-LMc6V1KOHFjKDU8wyDsIEJdV8o2bpc2OaYw2NxncJB2oZxJMPpiNVAbiu1HnqsUy81fkK1QWwFztVqY81hUFEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.17"
+				"tldts-core": "^7.0.23"
 			}
+		},
+		"node_modules/tldts/node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
@@ -20671,39 +21823,29 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"psl": "^1.1.33",
-				"punycode": "^2.1.1",
-				"universalify": "^0.2.0",
-				"url-parse": "^1.5.3"
+				"tldts": "^6.1.32"
 			},
 			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/tough-cookie/node_modules/universalify": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4.0.0"
+				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-			"integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"punycode": "^2.1.1"
+				"punycode": "^2.3.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/tree-kill": {
@@ -20848,6 +21990,7 @@
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -21013,6 +22156,13 @@
 				"through": "^2.3.8"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -21080,10 +22230,45 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/unrs-resolver": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"napi-postinstall": "^0.3.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unrs-resolver"
+			},
+			"optionalDependencies": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+				"@unrs/resolver-binding-android-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-x64": "1.11.1",
+				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+			}
+		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"funding": [
 				{
@@ -21099,9 +22284,10 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"escalade": "^3.2.0",
-				"picocolors": "^1.1.0"
+				"picocolors": "^1.1.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -21164,16 +22350,6 @@
 				"file-loader": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/url-parse": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-			"dev": true,
-			"dependencies": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -21245,15 +22421,16 @@
 			}
 		},
 		"node_modules/w3c-xmlserializer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-			"integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"xml-name-validator": "^4.0.0"
+				"xml-name-validator": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/wait-on": {
@@ -21315,9 +22492,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/webdriver-bidi-protocol": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.8.tgz",
-			"integrity": "sha512-21Yi2GhGntMc671vNBCjiAeEVknXjVRoyu+k+9xOMShu+ZQfpGQwnBqbNz/Sv4GXZ6JmutlPAi2nIJcrymAWuQ==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+			"integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -21326,6 +22503,7 @@
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
 			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
 			}
@@ -21774,37 +22952,41 @@
 			}
 		},
 		"node_modules/whatwg-encoding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-			"integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"iconv-lite": "0.6.3"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/whatwg-mimetype": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/whatwg-url": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-			"integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"tr46": "^3.0.0",
+				"tr46": "^5.1.0",
 				"webidl-conversions": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/when-exit": {
@@ -21904,9 +23086,9 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -22080,19 +23262,21 @@
 			}
 		},
 		"node_modules/xml-name-validator": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-			"integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/xmlchars": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
@@ -22233,15 +23417,36 @@
 				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
-		"@babel/code-frame": {
-			"version": "7.26.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+		"@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.25.9",
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "10.4.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.28.5",
 				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
+				"picocolors": "^1.1.1"
 			}
 		},
 		"@babel/compat-data": {
@@ -22271,14 +23476,6 @@
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.2.3",
 				"semver": "^6.3.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/eslint-parser": {
@@ -22290,14 +23487,6 @@
 				"@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
 				"eslint-visitor-keys": "^2.1.0",
 				"semver": "^6.3.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/generator": {
@@ -22363,12 +23552,6 @@
 						"yallist": "^3.0.2"
 					}
 				},
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				},
 				"yallist": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -22390,14 +23573,6 @@
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
 				"@babel/traverse": "^7.25.9",
 				"semver": "^6.3.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
@@ -22409,14 +23584,6 @@
 				"@babel/helper-annotate-as-pure": "^7.25.9",
 				"regexpu-core": "^6.2.0",
 				"semver": "^6.3.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-define-polyfill-provider": {
@@ -23258,14 +24425,6 @@
 				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"semver": "^6.3.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -23455,14 +24614,6 @@
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"core-js-compat": "^3.38.1",
 				"semver": "^6.3.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/preset-modules": {
@@ -23554,40 +24705,32 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"@cacheable/memoize": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@cacheable/memoize/-/memoize-2.0.3.tgz",
-			"integrity": "sha512-hl9wfQgpiydhQEIv7fkjEzTGE+tcosCXLKFDO707wYJ/78FVOlowb36djex5GdbSyeHnG62pomYLMuV/OT8Pbw==",
-			"dev": true,
-			"requires": {
-				"@cacheable/utils": "^2.0.3"
-			}
-		},
 		"@cacheable/memory": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.4.tgz",
-			"integrity": "sha512-cCmJKCKlT1t7hNBI1+gFCwmKFd9I4pS3zqBeNGXTSODnpa0EeDmORHY8oEMTuozfdg3cgsVh8ojLaPYb6eC7Cg==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+			"integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
 			"dev": true,
 			"requires": {
-				"@cacheable/utils": "^2.2.0",
-				"@keyv/bigmap": "^1.1.0",
-				"hookified": "^1.12.2",
-				"keyv": "^5.5.3"
+				"@cacheable/utils": "^2.4.0",
+				"@keyv/bigmap": "^1.3.1",
+				"hookified": "^1.15.1",
+				"keyv": "^5.6.0"
 			},
 			"dependencies": {
 				"@keyv/bigmap": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.1.0.tgz",
-					"integrity": "sha512-MX7XIUNwVRK+hjZcAbNJ0Z8DREo+Weu9vinBOjGU1thEi9F6vPhICzBbk4CCf3eEefKRz7n6TfZXwUFZTSgj8Q==",
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+					"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
 					"dev": true,
 					"requires": {
-						"hookified": "^1.12.2"
+						"hashery": "^1.4.0",
+						"hookified": "^1.15.0"
 					}
 				},
 				"keyv": {
-					"version": "5.5.3",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-					"integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+					"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 					"dev": true,
 					"requires": {
 						"@keyv/serialize": "^1.1.1"
@@ -23596,23 +24739,47 @@
 			}
 		},
 		"@cacheable/utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.2.0.tgz",
-			"integrity": "sha512-7xaQayO3msdVcxXLYcLU5wDqJBNdQcPPPHr6mdTEIQI7N7TbtSVVTpWOTfjyhg0L6AQwQdq7miKdWtTDBoBldQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+			"integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
 			"dev": true,
 			"requires": {
-				"keyv": "^5.5.3"
+				"hashery": "^1.5.0",
+				"keyv": "^5.6.0"
 			},
 			"dependencies": {
 				"keyv": {
-					"version": "5.5.3",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-					"integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+					"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 					"dev": true,
 					"requires": {
 						"@keyv/serialize": "^1.1.1"
 					}
 				}
+			}
+		},
+		"@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"dev": true
+		},
+		"@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"dev": true,
+			"requires": {}
+		},
+		"@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"dev": true,
+			"requires": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
 			}
 		},
 		"@csstools/css-parser-algorithms": {
@@ -23621,6 +24788,12 @@
 			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
 			"dev": true,
 			"requires": {}
+		},
+		"@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.0.28",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+			"integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+			"dev": true
 		},
 		"@csstools/css-tokenizer": {
 			"version": "3.0.4",
@@ -23647,6 +24820,37 @@
 			"integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
 			"dev": true
 		},
+		"@emnapi/core": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+			"integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@emnapi/wasi-threads": "1.1.0",
+				"tslib": "^2.4.0"
+			}
+		},
+		"@emnapi/runtime": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+			"integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"@emnapi/wasi-threads": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"@es-joy/jsdoccomment": {
 			"version": "0.41.0",
 			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
@@ -23659,9 +24863,9 @@
 			}
 		},
 		"@eslint-community/eslint-utils": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^3.4.3"
@@ -23714,9 +24918,9 @@
 					}
 				},
 				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+					"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 					"dev": true,
 					"requires": {
 						"argparse": "^2.0.1"
@@ -23920,6 +25124,159 @@
 				"jest-mock": "^29.7.0"
 			}
 		},
+		"@jest/environment-jsdom-abstract": {
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.2.0.tgz",
+			"integrity": "sha512-kazxw2L9IPuZpQ0mEt9lu9Z98SqR74xcagANmMBU16X0lS23yPc0+S6hGLUz8kVRlomZEs/5S/Zlpqwf5yu6OQ==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "30.2.0",
+				"@jest/fake-timers": "30.2.0",
+				"@jest/types": "30.2.0",
+				"@types/jsdom": "^21.1.7",
+				"@types/node": "*",
+				"jest-mock": "30.2.0",
+				"jest-util": "30.2.0"
+			},
+			"dependencies": {
+				"@jest/environment": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+					"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+					"dev": true,
+					"requires": {
+						"@jest/fake-timers": "30.2.0",
+						"@jest/types": "30.2.0",
+						"@types/node": "*",
+						"jest-mock": "30.2.0"
+					}
+				},
+				"@jest/fake-timers": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+					"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "30.2.0",
+						"@sinonjs/fake-timers": "^13.0.0",
+						"@types/node": "*",
+						"jest-message-util": "30.2.0",
+						"jest-mock": "30.2.0",
+						"jest-util": "30.2.0"
+					}
+				},
+				"@jest/schemas": {
+					"version": "30.0.5",
+					"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+					"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+					"dev": true,
+					"requires": {
+						"@sinclair/typebox": "^0.34.0"
+					}
+				},
+				"@jest/types": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+					"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+					"dev": true,
+					"requires": {
+						"@jest/pattern": "30.0.1",
+						"@jest/schemas": "30.0.5",
+						"@types/istanbul-lib-coverage": "^2.0.6",
+						"@types/istanbul-reports": "^3.0.4",
+						"@types/node": "*",
+						"@types/yargs": "^17.0.33",
+						"chalk": "^4.1.2"
+					}
+				},
+				"@sinclair/typebox": {
+					"version": "0.34.48",
+					"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+					"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+					"dev": true
+				},
+				"@sinonjs/fake-timers": {
+					"version": "13.0.5",
+					"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+					"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+					"dev": true,
+					"requires": {
+						"@sinonjs/commons": "^3.0.1"
+					}
+				},
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+					"dev": true
+				},
+				"ci-info": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+					"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+					"dev": true
+				},
+				"jest-message-util": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+					"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.27.1",
+						"@jest/types": "30.2.0",
+						"@types/stack-utils": "^2.0.3",
+						"chalk": "^4.1.2",
+						"graceful-fs": "^4.2.11",
+						"micromatch": "^4.0.8",
+						"pretty-format": "30.2.0",
+						"slash": "^3.0.0",
+						"stack-utils": "^2.0.6"
+					}
+				},
+				"jest-mock": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+					"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "30.2.0",
+						"@types/node": "*",
+						"jest-util": "30.2.0"
+					}
+				},
+				"jest-util": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+					"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "30.2.0",
+						"@types/node": "*",
+						"chalk": "^4.1.2",
+						"ci-info": "^4.2.0",
+						"graceful-fs": "^4.2.11",
+						"picomatch": "^4.0.2"
+					}
+				},
+				"picomatch": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+					"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+					"dev": true,
+					"requires": {
+						"@jest/schemas": "30.0.5",
+						"ansi-styles": "^5.2.0",
+						"react-is": "^18.3.1"
+					}
+				}
+			}
+		},
 		"@jest/expect": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
@@ -23963,6 +25320,24 @@
 				"@jest/expect": "^29.7.0",
 				"@jest/types": "^29.6.3",
 				"jest-mock": "^29.7.0"
+			}
+		},
+		"@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
+			},
+			"dependencies": {
+				"jest-regex-util": {
+					"version": "30.0.1",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+					"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+					"dev": true
+				}
 			}
 		},
 		"@jest/reporters": {
@@ -24023,9 +25398,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				},
 				"supports-color": {
@@ -24199,6 +25574,18 @@
 			"integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
 			"dev": true
 		},
+		"@napi-rs/wasm-runtime": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@emnapi/core": "^1.4.3",
+				"@emnapi/runtime": "^1.4.3",
+				"@tybys/wasm-util": "^0.10.0"
+			}
+		},
 		"@nicolo-ribaudo/eslint-scope-5-internals": {
 			"version": "5.1.1-v1",
 			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -24334,9 +25721,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				}
 			}
@@ -24443,9 +25830,9 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				}
 			}
@@ -24634,9 +26021,9 @@
 			}
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
-			"integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
 			"dev": true
 		},
 		"@opentelemetry/sql-common": {
@@ -24773,13 +26160,13 @@
 			"dev": true
 		},
 		"@playwright/test": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-			"integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"playwright": "1.56.1"
+				"playwright": "1.58.2"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -24890,15 +26277,15 @@
 			"dev": true
 		},
 		"@sentry/core": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.46.0.tgz",
-			"integrity": "sha512-it7JMFqxVproAgEtbLgCVBYtQ9fIb+Bu0JD+cEplTN/Ukpe6GaolyYib5geZqslVxhp2sQgT+58aGvfd/k0N8Q==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
+			"integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
 			"dev": true
 		},
 		"@sentry/node": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.46.0.tgz",
-			"integrity": "sha512-pRLqAcd7GTGvN8gex5FtkQR5Mcol8gOy1WlyZZFq4rBbVtMbqKOQRhohwqnb+YrnmtFpj7IZ7KNDo077MvNeOQ==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.47.1.tgz",
+			"integrity": "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==",
 			"dev": true,
 			"requires": {
 				"@opentelemetry/api": "^1.9.0",
@@ -24931,9 +26318,9 @@
 				"@opentelemetry/sdk-trace-base": "^1.30.1",
 				"@opentelemetry/semantic-conventions": "^1.34.0",
 				"@prisma/instrumentation": "6.11.1",
-				"@sentry/core": "9.46.0",
-				"@sentry/node-core": "9.46.0",
-				"@sentry/opentelemetry": "9.46.0",
+				"@sentry/core": "9.47.1",
+				"@sentry/node-core": "9.47.1",
+				"@sentry/opentelemetry": "9.47.1",
 				"import-in-the-middle": "^1.14.2",
 				"minimatch": "^9.0.0"
 			},
@@ -24948,34 +26335,34 @@
 					}
 				},
 				"minimatch": {
-					"version": "9.0.5",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-					"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+					"version": "9.0.9",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+					"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^2.0.1"
+						"brace-expansion": "^2.0.2"
 					}
 				}
 			}
 		},
 		"@sentry/node-core": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.46.0.tgz",
-			"integrity": "sha512-XRVu5pqoklZeh4wqhxCLZkz/ipoKhitctgEFXX9Yh1e1BoHM2pIxT52wf+W6hHM676TFmFXW3uKBjsmRM3AjgA==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.47.1.tgz",
+			"integrity": "sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==",
 			"dev": true,
 			"requires": {
-				"@sentry/core": "9.46.0",
-				"@sentry/opentelemetry": "9.46.0",
+				"@sentry/core": "9.47.1",
+				"@sentry/opentelemetry": "9.47.1",
 				"import-in-the-middle": "^1.14.2"
 			}
 		},
 		"@sentry/opentelemetry": {
-			"version": "9.46.0",
-			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.46.0.tgz",
-			"integrity": "sha512-w2zTxqrdmwRok0cXBoh+ksXdGRUHUZhlpfL/H2kfTodOL+Mk8rW72qUmfqQceXoqgbz8UyK8YgJbyt+XS5H4Qg==",
+			"version": "9.47.1",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
+			"integrity": "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==",
 			"dev": true,
 			"requires": {
-				"@sentry/core": "9.46.0"
+				"@sentry/core": "9.47.1"
 			}
 		},
 		"@sideway/address": {
@@ -25000,9 +26387,9 @@
 			"dev": true
 		},
 		"@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
 			"dev": true
 		},
 		"@sinonjs/commons": {
@@ -25257,6 +26644,16 @@
 			"integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
 			"dev": true
 		},
+		"@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"@types/babel__core": {
 			"version": "7.20.5",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -25435,9 +26832,9 @@
 			}
 		},
 		"@types/jsdom": {
-			"version": "20.0.1",
-			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
-			"integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+			"version": "21.1.7",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -25479,10 +26876,13 @@
 			}
 		},
 		"@types/node": {
-			"version": "17.0.29",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
-			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
-			"dev": true
+			"version": "20.19.35",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+			"integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+			"dev": true,
+			"requires": {
+				"undici-types": "~6.21.0"
+			}
 		},
 		"@types/node-forge": {
 			"version": "1.3.11",
@@ -25525,6 +26925,12 @@
 				"@types/pg": "*"
 			}
 		},
+		"@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"dev": true
+		},
 		"@types/qs": {
 			"version": "6.9.15",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
@@ -25536,6 +26942,23 @@
 			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
 			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
 			"dev": true
+		},
+		"@types/react": {
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+			"dev": true,
+			"requires": {
+				"@types/prop-types": "*",
+				"csstype": "^3.2.2"
+			}
+		},
+		"@types/react-dom": {
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"dev": true,
+			"requires": {}
 		},
 		"@types/retry": {
 			"version": "0.12.0",
@@ -25625,9 +27048,9 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "17.0.32",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
@@ -25669,9 +27092,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				}
 			}
@@ -25752,9 +27175,9 @@
 					}
 				},
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				}
 			}
@@ -25775,9 +27198,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				}
 			}
@@ -25805,6 +27228,142 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true
+		},
+		"@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-android-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-darwin-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@napi-rs/wasm-runtime": "^0.2.11"
+			}
+		},
+		"@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+			"dev": true,
+			"optional": true
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.14.1",
@@ -25974,9 +27533,9 @@
 			"requires": {}
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "8.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.34.0.tgz",
-			"integrity": "sha512-AJQesBDb1LcmwlfpIVkuTu0gwkjgfVdbKG6sqmKfKkjYTac6k+ZJscZqYWgjIK2G0F0/TZwbN6u4otRq+yDAGw==",
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.40.0.tgz",
+			"integrity": "sha512-UzSwDaxsMarnlfFUmEWW2qvkJy4JupW49uH0JztFobCamQ5QCL71M75zIspIXffiZVjQMBWruR7/+5QTJklewA==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "7.25.7",
@@ -25985,61 +27544,91 @@
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/browserslist-config": "^6.40.0",
+				"@wordpress/warning": "^3.40.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.16.0.tgz",
+			"integrity": "sha512-g8eZCTULM9rdQMTYfp3U+bHjT6wTtyuo8BFE2PCwJmH60Lp6P4qjnaez1PDW2M3yujCPwDdQBIR8tPXrTAlC/A==",
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
-			"version": "6.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.34.0.tgz",
-			"integrity": "sha512-pmcCkqG2jW+UUBSkX7rSZS33mcW6M0fKcJPD40TlK2cUZvECS5TDa2BC/b80PfIsT2kSw+Z9Wv+8eyX6I8HGjQ==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.40.0.tgz",
+			"integrity": "sha512-aX44MD4Kcr4LZT1YWa3VkMUUJjNfAgt7UECs/qrNGM8tC3l4/2Z4zRkJfpK3AoaXusb1J8+r5ZXWJWhxYK1JMQ==",
 			"dev": true
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.34.0.tgz",
-			"integrity": "sha512-lynP46WtxueExZoWzDgM02dSt/11J50Wu2jqRKCIAVsID75cPhjYS59kMAyTppa9R9s9J9ZEdqL0gqXsXr3+bw==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.40.0.tgz",
+			"integrity": "sha512-C6QZUieZoOEeZqT265EGIn95vIA1Nt6BPCOi1JyuJQ2hxOgk/cz4Vj7a31zJzCu/c1BKN3R6n78lB6nAuyZrVQ==",
 			"dev": true,
 			"requires": {
 				"json2php": "^0.0.7"
 			}
 		},
 		"@wordpress/e2e-test-utils-playwright": {
-			"version": "1.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.34.0.tgz",
-			"integrity": "sha512-CpbjtXGxiNDjRrVx3Foo4CG2aSpmiQIjEHxLj+ItKXmg9JsDr/1iYEBraOA12LX8tUaHaEll3ykByJebMR1OdA==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.40.0.tgz",
+			"integrity": "sha512-7EMx/5R0l9mlR4s01I06x8bw7qq30VlU98T/tvYJa+ycFQK3oetkoPyiNfki2Y2SILQGjI3Mu4MSV1NPCa/mEw==",
 			"dev": true,
 			"requires": {
 				"change-case": "^4.1.2",
-				"form-data": "^4.0.0",
 				"get-port": "^5.1.1",
 				"lighthouse": "^12.2.2",
 				"mime": "^3.0.0",
 				"web-vitals": "^4.2.1"
 			}
 		},
+		"@wordpress/element": {
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.40.0.tgz",
+			"integrity": "sha512-OhU8B2xEGg7c41rh/VRiJLOz6TnM/r5r8sraAg5ISc2bF7s2oAFqLwvlR0/U6ervyYwbK644osWZGQxFyL3huA==",
+			"dev": true,
+			"requires": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.40.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+					"dev": true
+				}
+			}
+		},
+		"@wordpress/escape-html": {
+			"version": "3.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.40.0.tgz",
+			"integrity": "sha512-DD6xWVbnw4fGGgO6DFDTJiLj52om0OG4cYHLz7ZhuipmOlEUGljPYOcrj8uxtlh5EFrqHCIPkOya+qQXUHUSBw==",
+			"dev": true
+		},
 		"@wordpress/eslint-plugin": {
-			"version": "22.20.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.20.0.tgz",
-			"integrity": "sha512-mZuEmBLLAOT6koBsXMrFMHQskKs+p+nu1Z/Y/4u1FldRlShdbKSXZG2p9qV3SVnXdSAEa5Cr32kOvkZGacEO/Q==",
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.2.0.tgz",
+			"integrity": "sha512-FBVWV+wZ1vN6fpSZVI8gMOJ8M1q69Lp1jMUzbH46lE+ICKnQDUeX6FkN/dZiG6rOSbHau+qEGbuPwTDe2D3quQ==",
 			"dev": true,
 			"requires": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.34.0",
-				"@wordpress/prettier-config": "^4.34.0",
+				"@wordpress/babel-preset-default": "^8.40.0",
+				"@wordpress/prettier-config": "^4.40.0",
+				"@wordpress/theme": "^0.7.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
+				"eslint-import-resolver-typescript": "^4.4.4",
 				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^27.4.3",
 				"eslint-plugin-jsdoc": "^46.4.6",
@@ -26070,68 +27659,75 @@
 			}
 		},
 		"@wordpress/jest-console": {
-			"version": "8.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.34.0.tgz",
-			"integrity": "sha512-CovQ/aJXMjWYrvtWzY+9+fkUXi6boVtp0t679AX3BYLtLiQTzLfrvDOb6H5jWyNzXmnHC6OJqRV+baw4qVyumg==",
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.40.0.tgz",
+			"integrity": "sha512-H7j9Afosm0TvppBjQmXxErUBdWIT0u1mX+toH1liafp0gpxzowYMbv1MAASgAEzPrbL/U0P68GIW3PQXQFO4xg==",
 			"dev": true,
 			"requires": {
-				"jest-matcher-utils": "^29.6.2"
+				"jest-matcher-utils": "^29.6.2",
+				"jest-mock": "^29.6.2"
 			}
 		},
 		"@wordpress/jest-preset-default": {
-			"version": "12.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.34.0.tgz",
-			"integrity": "sha512-Pxs4gnjtf6L/gde7rCdG9wjymCKPj8VjBWdVGOtvGC8FfXNPbKioI+AIqfwCquXJs2xCyDrGei3QfLQtvQ42/g==",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.40.0.tgz",
+			"integrity": "sha512-JkH6Hsesy6cyH+encol7jvQyMtFQYLZyb/VpUrZAfUfymOh7VtSqLSGVyxvw64OLcWKE+cE/xkApvvGFBHzG4w==",
 			"dev": true,
 			"requires": {
-				"@wordpress/jest-console": "^8.34.0",
+				"@wordpress/jest-console": "^8.40.0",
 				"babel-jest": "29.7.0"
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
-			"version": "5.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.34.0.tgz",
-			"integrity": "sha512-kLGKSxs/vDo+np++TmIpw8thebL1pCBDMdHOjweS8iwlXq2ZevXXIebG1CUk4td8cMoKW1byobtwsz2MwaEAig==",
+			"version": "5.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.40.0.tgz",
+			"integrity": "sha512-fxIya56Bf+LTnDR07RfAM5VfITl7uQm9kJkY4nUYNRC6xPj5cCLLsIh0x5UWXmYQxTTaSreMKYxDPe4UN7tATA==",
 			"dev": true,
 			"requires": {}
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "5.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.34.0.tgz",
-			"integrity": "sha512-TP1hsALuEhNRyCGw0YI8AYB1Lq8gFJ+X7etLpjtKlY+0zyiTb+fMrZuQRnYXzwjGhN9Ni9CB1l5U0YhJ8z3VqQ==",
+			"version": "5.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.40.0.tgz",
+			"integrity": "sha512-t8zryWpd6sLUVWbFLkRW9637Nmvx4Odnyu9jQCV5yfLXRubD37x/PVRVx7tUw9SpbbrPzKB4DqpNOF+dTHaICg==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^6.10.0",
+				"@wordpress/base-styles": "^6.16.0",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			}
 		},
 		"@wordpress/prettier-config": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.34.0.tgz",
-			"integrity": "sha512-vrcjpVegYSwTSC8JfcE/qmmv1lsqDDhKvLqT8rMhW4DiogH8sVThJ1w5o2qOELXON2ArqfAxW8+DVmHsTPCUzQ==",
+			"version": "4.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.40.0.tgz",
+			"integrity": "sha512-6JqPLZtoO1OnZJMVrWy+wwoCrJKD1VZnfNMLvNhhRoY7VypBXk189iyWj26JbOhBfFqIcVQNLNMTt9uTZDNujA==",
 			"dev": true,
 			"requires": {}
 		},
+		"@wordpress/private-apis": {
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.40.0.tgz",
+			"integrity": "sha512-68cwZKVq8Xy8GBzKoDRuV4b3pQ4nJFItY689HXp+poc0XXrnAeC4ZhjeSgS1qGRpFo6RVvLjjcaZsN2OrSSMvQ==",
+			"dev": true
+		},
 		"@wordpress/scripts": {
-			"version": "30.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.27.0.tgz",
-			"integrity": "sha512-gXGptazCxAaR7g8kcN5joj7B5fCm0VeBHOmnDBs2dbQ4W4F3tfzdg6CTEj8LonF9bWQXlSy3ku8EqWCdkSG9Xw==",
+			"version": "31.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.5.0.tgz",
+			"integrity": "sha512-7OS5bpHtnuagG8k9q9BdilHjhQ0MLhY0ypDgnRom5WlgPBshM/SUaF9bQLDnSDeasiD/bIgaDmoxWkfVZ4qSPQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.34.0",
-				"@wordpress/browserslist-config": "^6.34.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.34.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.34.0",
-				"@wordpress/eslint-plugin": "^22.20.0",
-				"@wordpress/jest-preset-default": "^12.34.0",
-				"@wordpress/npm-package-json-lint-config": "^5.34.0",
-				"@wordpress/postcss-plugins-preset": "^5.34.0",
-				"@wordpress/prettier-config": "^4.34.0",
-				"@wordpress/stylelint-config": "^23.26.0",
+				"@wordpress/babel-preset-default": "^8.40.0",
+				"@wordpress/browserslist-config": "^6.40.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.40.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.40.0",
+				"@wordpress/eslint-plugin": "^24.2.0",
+				"@wordpress/jest-preset-default": "^12.40.0",
+				"@wordpress/npm-package-json-lint-config": "^5.40.0",
+				"@wordpress/postcss-plugins-preset": "^5.40.0",
+				"@wordpress/prettier-config": "^4.40.0",
+				"@wordpress/stylelint-config": "^23.32.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -26144,13 +27740,13 @@
 				"cssnano": "^6.0.1",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^8.3.0",
+				"eslint": "^8.57.1",
 				"expect-puppeteer": "^4.4.0",
 				"fast-glob": "^3.2.7",
 				"filenamify": "^4.2.0",
 				"jest": "^29.6.2",
 				"jest-dev-server": "^10.1.4",
-				"jest-environment-jsdom": "^29.6.2",
+				"jest-environment-jsdom": "^30.2.0",
 				"jest-environment-node": "^29.6.2",
 				"json2php": "^0.0.9",
 				"markdownlint-cli": "^0.31.1",
@@ -26228,20 +27824,33 @@
 			}
 		},
 		"@wordpress/stylelint-config": {
-			"version": "23.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.26.0.tgz",
-			"integrity": "sha512-sLuvZjkX7gSeemthpZMHHD0MUuv86hp90eyMhIl2Zv3qARpGM6er8YIDtBbhqfIIWcrrfNQcXuR3G2DvL/CfwQ==",
+			"version": "23.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.32.0.tgz",
+			"integrity": "sha512-CvkKISBezOyzq6yc3+9ZnX0ar2qv3LGB1T8EcawCcwpESyVdfGu8vP7VZMKI8jDmsl2fUXXzt5nDScpXctY17Q==",
 			"dev": true,
 			"requires": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
+				"@wordpress/theme": "^0.7.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			}
 		},
+		"@wordpress/theme": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.7.0.tgz",
+			"integrity": "sha512-ULwLCSKYraIsv83bVH+Hm5pGFen6/0/8xOXQwxMdxeU+8kSm0cTKlpQPNvJGCmAeQb2OgFcowB/8wrUdyqW8UQ==",
+			"dev": true,
+			"requires": {
+				"@wordpress/element": "^6.40.0",
+				"@wordpress/private-apis": "^1.40.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			}
+		},
 		"@wordpress/warning": {
-			"version": "3.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.34.0.tgz",
-			"integrity": "sha512-WemuVXjaekzCDsWbDPj/RZSy44mIjPIy35DaoJgfLcgkXMH2GRBRSomhZMkWyGatD39vdXm0nqe95LsLDqrwCg==",
+			"version": "3.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.40.0.tgz",
+			"integrity": "sha512-0l3OFa1Z+UdhWRRHX9JWWKofo7Lbi2MqOFzzzn0MC26HOyfieQycjLVLNVNXaaodIKUhap6uDQq+JXbbHm881A==",
 			"dev": true
 		},
 		"@xtuc/ieee754": {
@@ -26283,16 +27892,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
 			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"dev": true
-		},
-		"acorn-globals": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
-			"integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-			"dev": true,
-			"requires": {
-				"acorn": "^8.1.0",
-				"acorn-walk": "^8.0.2"
-			}
 		},
 		"acorn-import-attributes": {
 			"version": "1.9.5",
@@ -26666,9 +28265,9 @@
 			"dev": true
 		},
 		"atomically": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.0.tgz",
-			"integrity": "sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+			"integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
 			"dev": true,
 			"requires": {
 				"stubborn-fs": "^2.0.0",
@@ -26676,15 +28275,14 @@
 			}
 		},
 		"autoprefixer": {
-			"version": "10.4.21",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-			"integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+			"version": "10.4.27",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+			"integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.24.4",
-				"caniuse-lite": "^1.0.30001702",
-				"fraction.js": "^4.3.7",
-				"normalize-range": "^0.1.2",
+				"browserslist": "^4.28.1",
+				"caniuse-lite": "^1.0.30001774",
+				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
 			}
@@ -26699,9 +28297,9 @@
 			}
 		},
 		"axe-core": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-			"integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+			"integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
 			"dev": true
 		},
 		"axios": {
@@ -26827,14 +28425,6 @@
 				"@babel/compat-data": "^7.22.6",
 				"@babel/helper-define-polyfill-provider": "^0.6.2",
 				"semver": "^6.3.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				}
 			}
 		},
 		"babel-plugin-polyfill-corejs3": {
@@ -26945,6 +28535,12 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true
+		},
+		"baseline-browser-mapping": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+			"integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
 			"dev": true
 		},
 		"basic-ftp": {
@@ -27065,15 +28661,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.24.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001688",
-				"electron-to-chromium": "^1.5.73",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.1"
+				"baseline-browser-mapping": "^2.9.0",
+				"caniuse-lite": "^1.0.30001759",
+				"electron-to-chromium": "^1.5.263",
+				"node-releases": "^2.0.27",
+				"update-browserslist-db": "^1.2.0"
 			}
 		},
 		"bser": {
@@ -27172,23 +28769,22 @@
 			}
 		},
 		"cacheable": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.1.1.tgz",
-			"integrity": "sha512-LmF4AXiSNdiRbI2UjH8pAp9NIXxeQsTotpEaegPiDcnN0YPygDJDV3l/Urc0mL72JWdATEorKqIHEx55nDlONg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
+			"integrity": "sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==",
 			"dev": true,
 			"requires": {
-				"@cacheable/memoize": "^2.0.3",
-				"@cacheable/memory": "^2.0.3",
-				"@cacheable/utils": "^2.1.0",
-				"hookified": "^1.12.2",
-				"keyv": "^5.5.3",
-				"qified": "^0.5.0"
+				"@cacheable/memory": "^2.0.8",
+				"@cacheable/utils": "^2.4.0",
+				"hookified": "^1.15.0",
+				"keyv": "^5.6.0",
+				"qified": "^0.6.0"
 			},
 			"dependencies": {
 				"keyv": {
-					"version": "5.5.3",
-					"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-					"integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+					"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 					"dev": true,
 					"requires": {
 						"@keyv/serialize": "^1.1.1"
@@ -27282,9 +28878,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001713",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
-			"integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
+			"version": "1.0.30001775",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001775.tgz",
+			"integrity": "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==",
 			"dev": true
 		},
 		"capital-case": {
@@ -27552,6 +29148,12 @@
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
 		},
+		"colorjs.io": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+			"dev": true
+		},
 		"combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -27778,9 +29380,9 @@
 			}
 		},
 		"core-js": {
-			"version": "3.46.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
-			"integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
 			"dev": true
 		},
 		"core-js-compat": {
@@ -27857,9 +29459,9 @@
 			"requires": {}
 		},
 		"css-functions-list": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-			"integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+			"integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
 			"dev": true
 		},
 		"css-loader": {
@@ -28021,28 +29623,21 @@
 				}
 			}
 		},
-		"cssom": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-			"dev": true
-		},
 		"cssstyle": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
 			"dev": true,
 			"requires": {
-				"cssom": "~0.3.6"
-			},
-			"dependencies": {
-				"cssom": {
-					"version": "0.3.8",
-					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-					"dev": true
-				}
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
 			}
+		},
+		"csstype": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"dev": true
 		},
 		"cwd": {
 			"version": "0.10.0",
@@ -28067,14 +29662,13 @@
 			"dev": true
 		},
 		"data-urls": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-			"integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.6",
-				"whatwg-mimetype": "^3.0.0",
-				"whatwg-url": "^11.0.0"
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
 			}
 		},
 		"data-view-buffer": {
@@ -28158,15 +29752,15 @@
 			}
 		},
 		"decimal.js": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"dev": true
 		},
 		"dedent": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-			"integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
+			"integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
 			"dev": true,
 			"requires": {}
 		},
@@ -28334,15 +29928,6 @@
 			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
 			"dev": true
 		},
-		"domexception": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-			"integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-			"dev": true,
-			"requires": {
-				"webidl-conversions": "^7.0.0"
-			}
-		},
 		"domhandler": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
@@ -28414,9 +29999,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.5.136",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz",
-			"integrity": "sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==",
+			"version": "1.5.302",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+			"integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
 			"dev": true
 		},
 		"emittery": {
@@ -28531,9 +30116,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-			"integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+			"version": "1.24.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+			"integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
 			"dev": true,
 			"requires": {
 				"array-buffer-byte-length": "^1.0.2",
@@ -28605,26 +30190,26 @@
 			"dev": true
 		},
 		"es-iterator-helpers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
-			"integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
+			"integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
+				"call-bound": "^1.0.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.6",
+				"es-abstract": "^1.24.1",
 				"es-errors": "^1.3.0",
-				"es-set-tostringtag": "^2.0.3",
+				"es-set-tostringtag": "^2.1.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.6",
+				"get-intrinsic": "^1.3.0",
 				"globalthis": "^1.0.4",
 				"gopd": "^1.2.0",
 				"has-property-descriptors": "^1.0.2",
 				"has-proto": "^1.2.0",
 				"has-symbols": "^1.1.0",
 				"internal-slot": "^1.1.0",
-				"iterator.prototype": "^1.1.4",
+				"iterator.prototype": "^1.1.5",
 				"safe-array-concat": "^1.1.3"
 			}
 		},
@@ -28793,9 +30378,9 @@
 					}
 				},
 				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+					"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 					"dev": true,
 					"requires": {
 						"argparse": "^2.0.1"
@@ -28834,6 +30419,16 @@
 			"dev": true,
 			"requires": {}
 		},
+		"eslint-import-context": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+			"integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+			"dev": true,
+			"requires": {
+				"get-tsconfig": "^4.10.1",
+				"stable-hash-x": "^0.2.0"
+			}
+		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -28854,6 +30449,21 @@
 						"ms": "^2.1.1"
 					}
 				}
+			}
+		},
+		"eslint-import-resolver-typescript": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+			"integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.4.1",
+				"eslint-import-context": "^0.1.8",
+				"get-tsconfig": "^4.10.1",
+				"is-bun-module": "^2.0.0",
+				"stable-hash-x": "^0.2.0",
+				"tinyglobby": "^0.2.14",
+				"unrs-resolver": "^1.7.11"
 			}
 		},
 		"eslint-module-utils": {
@@ -28920,12 +30530,6 @@
 					"requires": {
 						"esutils": "^2.0.2"
 					}
-				},
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
 				}
 			}
 		},
@@ -29002,9 +30606,9 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				}
 			}
@@ -29027,9 +30631,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				},
 				"spdx-expression-parse": {
@@ -29075,13 +30679,13 @@
 			"requires": {}
 		},
 		"eslint-plugin-prettier": {
-			"version": "5.5.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-			"integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+			"version": "5.5.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
 			"dev": true,
 			"requires": {
-				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.11.7"
+				"prettier-linter-helpers": "^1.0.1",
+				"synckit": "^0.11.12"
 			}
 		},
 		"eslint-plugin-react": {
@@ -29120,21 +30724,18 @@
 					}
 				},
 				"resolve": {
-					"version": "2.0.0-next.5",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-					"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+					"version": "2.0.0-next.6",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+					"integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
 					"dev": true,
 					"requires": {
-						"is-core-module": "^2.13.0",
+						"es-errors": "^1.3.0",
+						"is-core-module": "^2.16.1",
+						"node-exports-info": "^1.6.0",
+						"object-keys": "^1.1.1",
 						"path-parse": "^1.0.7",
 						"supports-preserve-symlinks-flag": "^1.0.0"
 					}
-				},
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
 				}
 			}
 		},
@@ -29195,9 +30796,9 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
@@ -29752,9 +31353,9 @@
 			"dev": true
 		},
 		"fraction.js": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-			"integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+			"integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
 			"dev": true
 		},
 		"fresh": {
@@ -29917,6 +31518,15 @@
 				"call-bound": "^1.0.3",
 				"es-errors": "^1.3.0",
 				"get-intrinsic": "^1.2.6"
+			}
+		},
+		"get-tsconfig": {
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+			"dev": true,
+			"requires": {
+				"resolve-pkg-maps": "^1.0.0"
 			}
 		},
 		"get-uri": {
@@ -30154,6 +31764,15 @@
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 			"dev": true
 		},
+		"hashery": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+			"integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+			"dev": true,
+			"requires": {
+				"hookified": "^1.14.0"
+			}
+		},
 		"hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -30183,9 +31802,9 @@
 			}
 		},
 		"hookified": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.2.tgz",
-			"integrity": "sha512-aokUX1VdTpI0DUsndvW+OiwmBpKCu/NgRsSSkuSY0zq8PY6Q6a+lmOfAFDXAAOtBqJELvcWY9L1EVtzjbQcMdg==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+			"integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
 			"dev": true
 		},
 		"hosted-git-info": {
@@ -30253,12 +31872,12 @@
 			}
 		},
 		"html-encoding-sniffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-			"integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^2.0.0"
+				"whatwg-encoding": "^3.1.1"
 			}
 		},
 		"html-entities": {
@@ -30665,6 +32284,23 @@
 			"dev": true,
 			"requires": {
 				"builtin-modules": "^3.3.0"
+			}
+		},
+		"is-bun-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+			"integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.7.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+					"dev": true
+				}
 			}
 		},
 		"is-callable": {
@@ -31170,19 +32806,154 @@
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
-			"integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.2.0.tgz",
+			"integrity": "sha512-zbBTiqr2Vl78pKp/laGBREYzbZx9ZtqPjOK4++lL4BNDhxRnahg51HtoDrk9/VjIy9IthNEWdKVd7H5bqBhiWQ==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/jsdom": "^20.0.0",
+				"@jest/environment": "30.2.0",
+				"@jest/environment-jsdom-abstract": "30.2.0",
+				"@types/jsdom": "^21.1.7",
 				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jsdom": "^20.0.0"
+				"jsdom": "^26.1.0"
+			},
+			"dependencies": {
+				"@jest/environment": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+					"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+					"dev": true,
+					"requires": {
+						"@jest/fake-timers": "30.2.0",
+						"@jest/types": "30.2.0",
+						"@types/node": "*",
+						"jest-mock": "30.2.0"
+					}
+				},
+				"@jest/fake-timers": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+					"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "30.2.0",
+						"@sinonjs/fake-timers": "^13.0.0",
+						"@types/node": "*",
+						"jest-message-util": "30.2.0",
+						"jest-mock": "30.2.0",
+						"jest-util": "30.2.0"
+					}
+				},
+				"@jest/schemas": {
+					"version": "30.0.5",
+					"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+					"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+					"dev": true,
+					"requires": {
+						"@sinclair/typebox": "^0.34.0"
+					}
+				},
+				"@jest/types": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+					"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+					"dev": true,
+					"requires": {
+						"@jest/pattern": "30.0.1",
+						"@jest/schemas": "30.0.5",
+						"@types/istanbul-lib-coverage": "^2.0.6",
+						"@types/istanbul-reports": "^3.0.4",
+						"@types/node": "*",
+						"@types/yargs": "^17.0.33",
+						"chalk": "^4.1.2"
+					}
+				},
+				"@sinclair/typebox": {
+					"version": "0.34.48",
+					"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+					"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+					"dev": true
+				},
+				"@sinonjs/fake-timers": {
+					"version": "13.0.5",
+					"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+					"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+					"dev": true,
+					"requires": {
+						"@sinonjs/commons": "^3.0.1"
+					}
+				},
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+					"dev": true
+				},
+				"ci-info": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+					"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+					"dev": true
+				},
+				"jest-message-util": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+					"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.27.1",
+						"@jest/types": "30.2.0",
+						"@types/stack-utils": "^2.0.3",
+						"chalk": "^4.1.2",
+						"graceful-fs": "^4.2.11",
+						"micromatch": "^4.0.8",
+						"pretty-format": "30.2.0",
+						"slash": "^3.0.0",
+						"stack-utils": "^2.0.6"
+					}
+				},
+				"jest-mock": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+					"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "30.2.0",
+						"@types/node": "*",
+						"jest-util": "30.2.0"
+					}
+				},
+				"jest-util": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+					"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "30.2.0",
+						"@types/node": "*",
+						"chalk": "^4.1.2",
+						"ci-info": "^4.2.0",
+						"graceful-fs": "^4.2.11",
+						"picomatch": "^4.0.2"
+					}
+				},
+				"picomatch": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "30.2.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+					"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+					"dev": true,
+					"requires": {
+						"@jest/schemas": "30.0.5",
+						"ansi-styles": "^5.2.0",
+						"react-is": "^18.3.1"
+					}
+				}
 			}
 		},
 		"jest-environment-node": {
@@ -31449,9 +33220,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				}
 			}
@@ -31560,9 +33331,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -31576,53 +33347,56 @@
 			"dev": true
 		},
 		"jsdom": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-			"integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.6",
-				"acorn": "^8.8.1",
-				"acorn-globals": "^7.0.0",
-				"cssom": "^0.5.0",
-				"cssstyle": "^2.3.0",
-				"data-urls": "^3.0.2",
-				"decimal.js": "^10.4.2",
-				"domexception": "^4.0.0",
-				"escodegen": "^2.0.0",
-				"form-data": "^4.0.0",
-				"html-encoding-sniffer": "^3.0.0",
-				"http-proxy-agent": "^5.0.0",
-				"https-proxy-agent": "^5.0.1",
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
 				"is-potential-custom-element-name": "^1.0.1",
-				"nwsapi": "^2.2.2",
-				"parse5": "^7.1.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^4.1.2",
-				"w3c-xmlserializer": "^4.0.0",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
 				"webidl-conversions": "^7.0.0",
-				"whatwg-encoding": "^2.0.0",
-				"whatwg-mimetype": "^3.0.0",
-				"whatwg-url": "^11.0.0",
-				"ws": "^8.11.0",
-				"xml-name-validator": "^4.0.0"
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
 			},
 			"dependencies": {
-				"@tootallnate/once": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-					"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+				"agent-base": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+					"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 					"dev": true
 				},
 				"http-proxy-agent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-					"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+					"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
 					"dev": true,
 					"requires": {
-						"@tootallnate/once": "2",
-						"agent-base": "6",
+						"agent-base": "^7.1.0",
+						"debug": "^4.3.4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+					"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.2",
 						"debug": "4"
 					}
 				}
@@ -31813,39 +33587,39 @@
 			},
 			"dependencies": {
 				"@puppeteer/browsers": {
-					"version": "2.10.13",
-					"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.13.tgz",
-					"integrity": "sha512-a9Ruw3j3qlnB5a/zHRTkruppynxqaeE4H9WNj5eYGRWqw0ZauZ23f4W2ARf3hghF5doozyD+CRtt7XSYuYRI/Q==",
+					"version": "2.13.0",
+					"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+					"integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
 					"dev": true,
 					"requires": {
 						"debug": "^4.4.3",
 						"extract-zip": "^2.0.1",
 						"progress": "^2.0.3",
 						"proxy-agent": "^6.5.0",
-						"semver": "^7.7.3",
+						"semver": "^7.7.4",
 						"tar-fs": "^3.1.1",
 						"yargs": "^17.7.2"
 					}
 				},
 				"puppeteer-core": {
-					"version": "24.28.0",
-					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.28.0.tgz",
-					"integrity": "sha512-QpAqaYgeZHF5/xAZ4jAOzsU+l0Ed4EJoWkRdfw8rNqmSN7itcdYeCJaSPQ0s5Pyn/eGNC4xNevxbgY+5bzNllw==",
+					"version": "24.37.5",
+					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.5.tgz",
+					"integrity": "sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ==",
 					"dev": true,
 					"requires": {
-						"@puppeteer/browsers": "2.10.13",
-						"chromium-bidi": "10.5.1",
+						"@puppeteer/browsers": "2.13.0",
+						"chromium-bidi": "14.0.0",
 						"debug": "^4.4.3",
-						"devtools-protocol": "0.0.1521046",
+						"devtools-protocol": "0.0.1566079",
 						"typed-query-selector": "^2.12.0",
-						"webdriver-bidi-protocol": "0.3.8",
-						"ws": "^8.18.3"
+						"webdriver-bidi-protocol": "0.4.1",
+						"ws": "^8.19.0"
 					},
 					"dependencies": {
 						"chromium-bidi": {
-							"version": "10.5.1",
-							"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.5.1.tgz",
-							"integrity": "sha512-rlj6OyhKhVTnk4aENcUme3Jl9h+cq4oXu4AzBcvr8RMmT6BR4a3zSNT9dbIfXr9/BS6ibzRyDhowuw4n2GgzsQ==",
+							"version": "14.0.0",
+							"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+							"integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
 							"dev": true,
 							"requires": {
 								"mitt": "^3.0.1",
@@ -31853,24 +33627,24 @@
 							}
 						},
 						"devtools-protocol": {
-							"version": "0.0.1521046",
-							"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
-							"integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
+							"version": "0.0.1566079",
+							"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
+							"integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
 							"dev": true
 						},
 						"ws": {
-							"version": "8.18.3",
-							"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-							"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+							"version": "8.19.0",
+							"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+							"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 							"dev": true,
 							"requires": {}
 						}
 					}
 				},
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				},
 				"ws": {
@@ -31932,30 +33706,29 @@
 			}
 		},
 		"lint-staged": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.6.tgz",
-			"integrity": "sha512-s1gphtDbV4bmW1eylXpVMk2u7is7YsrLl8hzrtvC70h4ByhcMLZFY01Fx05ZUDNuv1H8HO4E+e2zgejV1jVwNw==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.1.tgz",
+			"integrity": "sha512-bqvvquXzFBAlSbluugR4KXAe4XnO/QZcKVszpkBtqLWa2KEiVy8n6Xp38OeUbv/gOJOX4Vo9u5pFt/ADvbm42Q==",
 			"dev": true,
 			"requires": {
-				"commander": "^14.0.1",
+				"commander": "^14.0.3",
 				"listr2": "^9.0.5",
 				"micromatch": "^4.0.8",
-				"nano-spawn": "^2.0.0",
-				"pidtree": "^0.6.0",
 				"string-argv": "^0.3.2",
-				"yaml": "^2.8.1"
+				"tinyexec": "^1.0.2",
+				"yaml": "^2.8.2"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "14.0.2",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-					"integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+					"version": "14.0.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+					"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
 					"dev": true
 				},
 				"yaml": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-					"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+					"version": "2.8.2",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+					"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
 					"dev": true
 				}
 			}
@@ -32058,9 +33831,9 @@
 			"dev": true
 		},
 		"lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
 			"dev": true
 		},
 		"lodash.debounce": {
@@ -32222,9 +33995,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				}
 			}
@@ -32427,6 +34200,12 @@
 			"requires": {
 				"fs-monkey": "^1.0.4"
 			}
+		},
+		"memize": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
+			"dev": true
 		},
 		"meow": {
 			"version": "9.0.0",
@@ -32784,16 +34563,16 @@
 			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
 			"dev": true
 		},
-		"nano-spawn": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-			"integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-			"dev": true
-		},
 		"nanoid": {
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
 			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true
+		},
+		"napi-postinstall": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -32835,6 +34614,18 @@
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
 			"dev": true
+		},
+		"node-exports-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+			"dev": true,
+			"requires": {
+				"array.prototype.flatmap": "^1.3.3",
+				"es-errors": "^1.3.0",
+				"object.entries": "^1.1.9",
+				"semver": "^6.3.1"
+			}
 		},
 		"node-forge": {
 			"version": "1.3.1",
@@ -32954,9 +34745,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"version": "2.0.27",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
 			"dev": true
 		},
 		"node-sass": {
@@ -33247,12 +35038,6 @@
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true
 		},
-		"normalize-range": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-			"dev": true
-		},
 		"npm-bundled": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -33318,9 +35103,9 @@
 					"dev": true
 				},
 				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+					"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 					"dev": true,
 					"requires": {
 						"argparse": "^2.0.1"
@@ -33333,9 +35118,9 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 					"dev": true
 				},
 				"type-fest": {
@@ -33377,9 +35162,9 @@
 			}
 		},
 		"nwsapi": {
-			"version": "2.2.10",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
-			"integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==",
+			"version": "2.2.23",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
 			"dev": true
 		},
 		"object-assign": {
@@ -33716,12 +35501,20 @@
 			"dev": true
 		},
 		"parse5": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
 			"dev": true,
 			"requires": {
-				"entities": "^4.4.0"
+				"entities": "^6.0.0"
+			},
+			"dependencies": {
+				"entities": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+					"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+					"dev": true
+				}
 			}
 		},
 		"parseurl": {
@@ -33799,9 +35592,9 @@
 			"dev": true
 		},
 		"pg-protocol": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.12.0.tgz",
+			"integrity": "sha512-uOANXNRACNdElMXJ0tPz6RBM0XQ61nONGAwlt8da5zs/iUOOCLBQOHSXnrC6fMsvtjxbOJrZZl5IScGv+7mpbg==",
 			"dev": true
 		},
 		"pg-types": {
@@ -33829,12 +35622,6 @@
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true
 		},
-		"pidtree": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-			"integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-			"dev": true
-		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -33857,20 +35644,20 @@
 			}
 		},
 		"playwright": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-			"integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
 			"dev": true,
 			"peer": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.56.1"
+				"playwright-core": "1.58.2"
 			}
 		},
 		"playwright-core": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-			"integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+			"version": "1.58.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
 			"dev": true,
 			"peer": true
 		},
@@ -34283,9 +36070,9 @@
 			"dev": true
 		},
 		"postgres-bytea": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-			"integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+			"integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
 			"dev": true
 		},
 		"postgres-date": {
@@ -34316,9 +36103,9 @@
 			"dev": true
 		},
 		"prettier-linter-helpers": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+			"integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
 			"dev": true,
 			"requires": {
 				"fast-diff": "^1.1.2"
@@ -34479,12 +36266,6 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
-		"psl": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-			"dev": true
-		},
 		"pump": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -34496,9 +36277,9 @@
 			}
 		},
 		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true
 		},
 		"puppeteer-core": {
@@ -34530,12 +36311,12 @@
 			"dev": true
 		},
 		"qified": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/qified/-/qified-0.5.1.tgz",
-			"integrity": "sha512-+BtFN3dCP+IaFA6IYNOu/f/uK1B8xD2QWyOeCse0rjtAebBmkzgd2d1OAXi3ikAzJMIBSdzZDNZ3wZKEUDQs5w==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+			"integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
 			"dev": true,
 			"requires": {
-				"hookified": "^1.12.2"
+				"hookified": "^1.14.0"
 			}
 		},
 		"qs": {
@@ -34546,12 +36327,6 @@
 			"requires": {
 				"side-channel": "^1.0.4"
 			}
-		},
-		"querystringify": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-			"dev": true
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
@@ -34623,7 +36398,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -34921,6 +36695,12 @@
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 			"dev": true
 		},
+		"resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true
+		},
 		"resolve.exports": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -34985,6 +36765,12 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
 			"integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+			"dev": true
+		},
+		"rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
 			"dev": true
 		},
 		"rtlcss": {
@@ -35141,9 +36927,9 @@
 			}
 		},
 		"sass-loader": {
-			"version": "16.0.6",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.6.tgz",
-			"integrity": "sha512-sglGzId5gmlfxNs4gK2U3h7HlVRfx278YK6Ono5lwzuvi1jxig80YiuHkaDBVsYIKFhx8wN7XSCI0M2IDS/3qA==",
+			"version": "16.0.7",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+			"integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.2"
@@ -35163,7 +36949,6 @@
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
 			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"loose-envify": "^1.1.0"
 			}
@@ -35214,9 +36999,9 @@
 			}
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true
 		},
 		"send": {
@@ -35755,6 +37540,12 @@
 				"minipass": "^3.1.1"
 			}
 		},
+		"stable-hash-x": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+			"integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+			"dev": true
+		},
 		"stack-utils": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -36065,12 +37856,13 @@
 			}
 		},
 		"stylelint": {
-			"version": "16.25.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.25.0.tgz",
-			"integrity": "sha512-Li0avYWV4nfv1zPbdnxLYBGq4z8DVZxbRgx4Kn6V+Uftz1rMoF1qiEI3oL4kgWqyYgCgs7gT5maHNZ82Gk03vQ==",
+			"version": "16.26.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
 			"dev": true,
 			"requires": {
 				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
 				"@csstools/css-tokenizer": "^3.0.4",
 				"@csstools/media-query-list-parser": "^4.0.3",
 				"@csstools/selector-specificity": "^5.0.0",
@@ -36083,7 +37875,7 @@
 				"debug": "^4.4.3",
 				"fast-glob": "^3.3.3",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^10.1.4",
+				"file-entry-cache": "^11.1.1",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
@@ -36165,23 +37957,23 @@
 					"dev": true
 				},
 				"file-entry-cache": {
-					"version": "10.1.4",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
-					"integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
+					"version": "11.1.2",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+					"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
 					"dev": true,
 					"requires": {
-						"flat-cache": "^6.1.13"
+						"flat-cache": "^6.1.20"
 					}
 				},
 				"flat-cache": {
-					"version": "6.1.18",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.18.tgz",
-					"integrity": "sha512-JUPnFgHMuAVmLmoH9/zoZ6RHOt5n9NlUw/sDXsTbROJ2SFoS2DS4s+swAV6UTeTbGH/CAsZIE6M8TaG/3jVxgQ==",
+					"version": "6.1.20",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+					"integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
 					"dev": true,
 					"requires": {
-						"cacheable": "^2.1.0",
+						"cacheable": "^2.3.2",
 						"flatted": "^3.3.3",
-						"hookified": "^1.12.0"
+						"hookified": "^1.15.0"
 					}
 				},
 				"global-modules": {
@@ -36223,9 +38015,9 @@
 					"dev": true
 				},
 				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+					"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 					"dev": true,
 					"requires": {
 						"argparse": "^2.0.1"
@@ -36250,9 +38042,9 @@
 					"dev": true
 				},
 				"postcss-selector-parser": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-					"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+					"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 					"dev": true,
 					"requires": {
 						"cssesc": "^3.0.0",
@@ -36316,18 +38108,18 @@
 			}
 		},
 		"stylelint-scss": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
-			"integrity": "sha512-UJUfBFIvXfly8WKIgmqfmkGKPilKB4L5j38JfsDd+OCg2GBdU0vGUV08Uw82tsRZzd4TbsUURVVNGeOhJVF7pA==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
+			"integrity": "sha512-ZKmHMZolxeuYsnB+PCYrTpFce0/QWX9i9gh0hPXzp73WjuIMqUpzdQaBCrKoLWh6XtCFSaNDErkMPqdjy1/8aA==",
 			"dev": true,
 			"requires": {
 				"css-tree": "^3.0.1",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.36.0",
-				"mdn-data": "^2.21.0",
+				"known-css-properties": "^0.37.0",
+				"mdn-data": "^2.25.0",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.6",
-				"postcss-selector-parser": "^7.1.0",
+				"postcss-selector-parser": "^7.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"dependencies": {
@@ -36355,22 +38147,16 @@
 					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				},
-				"known-css-properties": {
-					"version": "0.36.0",
-					"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
-					"integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
-					"dev": true
-				},
 				"mdn-data": {
-					"version": "2.25.0",
-					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.25.0.tgz",
-					"integrity": "sha512-T2LPsjgUE/tgMmRXREVmwsux89DwWfNjiynOeXuLd2mX6jphGQ2YE3Ukz7LQ2VOFKiVZU/Ee1GqzHiipZCjymw==",
+					"version": "2.27.1",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+					"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 					"dev": true
 				},
 				"postcss-selector-parser": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-					"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+					"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 					"dev": true,
 					"requires": {
 						"cssesc": "^3.0.0",
@@ -36446,9 +38232,9 @@
 			"dev": true
 		},
 		"synckit": {
-			"version": "0.11.11",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-			"integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
 			"dev": true,
 			"requires": {
 				"@pkgr/core": "^0.2.9"
@@ -36468,9 +38254,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.17.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+					"version": "8.18.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+					"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.3",
@@ -36659,19 +38445,67 @@
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
 		},
+		"tinyexec": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"dev": true
+		},
+		"tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"requires": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"dependencies": {
+				"fdir": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+					"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+					"dev": true,
+					"requires": {}
+				},
+				"picomatch": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+					"dev": true
+				}
+			}
+		},
+		"tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"dev": true,
+			"requires": {
+				"tldts-core": "^6.1.86"
+			},
+			"dependencies": {
+				"tldts-core": {
+					"version": "6.1.86",
+					"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+					"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+					"dev": true
+				}
+			}
+		},
 		"tldts-core": {
-			"version": "7.0.17",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.17.tgz",
-			"integrity": "sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==",
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+			"integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
 			"dev": true
 		},
 		"tldts-icann": {
-			"version": "7.0.17",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.17.tgz",
-			"integrity": "sha512-up4oFDoumyz2RscRxoYRxf+2OvIKUHjh7rUvuGWI0PZ/47k35sadoi2JyKR0AIfTw09qcfix8bUxXFQhY1QZIQ==",
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.23.tgz",
+			"integrity": "sha512-LMc6V1KOHFjKDU8wyDsIEJdV8o2bpc2OaYw2NxncJB2oZxJMPpiNVAbiu1HnqsUy81fkK1QWwFztVqY81hUFEg==",
 			"dev": true,
 			"requires": {
-				"tldts-core": "^7.0.17"
+				"tldts-core": "^7.0.23"
 			}
 		},
 		"tmpl": {
@@ -36702,32 +38536,21 @@
 			"dev": true
 		},
 		"tough-cookie": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.33",
-				"punycode": "^2.1.1",
-				"universalify": "^0.2.0",
-				"url-parse": "^1.5.3"
-			},
-			"dependencies": {
-				"universalify": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-					"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-					"dev": true
-				}
+				"tldts": "^6.1.32"
 			}
 		},
 		"tr46": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-			"integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.1"
+				"punycode": "^2.3.1"
 			}
 		},
 		"tree-kill": {
@@ -36949,6 +38772,12 @@
 				"through": "^2.3.8"
 			}
 		},
+		"undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true
+		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -37001,14 +38830,42 @@
 			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
 			"dev": true
 		},
+		"unrs-resolver": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+			"dev": true,
+			"requires": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+				"@unrs/resolver-binding-android-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-x64": "1.11.1",
+				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1",
+				"napi-postinstall": "^0.3.0"
+			}
+		},
 		"update-browserslist-db": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"requires": {
 				"escalade": "^3.2.0",
-				"picocolors": "^1.1.0"
+				"picocolors": "^1.1.1"
 			}
 		},
 		"upper-case": {
@@ -37047,16 +38904,6 @@
 				"loader-utils": "^2.0.0",
 				"mime-types": "^2.1.27",
 				"schema-utils": "^3.0.0"
-			}
-		},
-		"url-parse": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-			"dev": true,
-			"requires": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
 			}
 		},
 		"util-deprecate": {
@@ -37111,12 +38958,12 @@
 			"dev": true
 		},
 		"w3c-xmlserializer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-			"integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
 			"dev": true,
 			"requires": {
-				"xml-name-validator": "^4.0.0"
+				"xml-name-validator": "^5.0.0"
 			}
 		},
 		"wait-on": {
@@ -37167,9 +39014,9 @@
 			"dev": true
 		},
 		"webdriver-bidi-protocol": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.8.tgz",
-			"integrity": "sha512-21Yi2GhGntMc671vNBCjiAeEVknXjVRoyu+k+9xOMShu+ZQfpGQwnBqbNz/Sv4GXZ6JmutlPAi2nIJcrymAWuQ==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+			"integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
 			"dev": true
 		},
 		"webidl-conversions": {
@@ -37482,27 +39329,27 @@
 			"dev": true
 		},
 		"whatwg-encoding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-			"integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
 			"dev": true,
 			"requires": {
 				"iconv-lite": "0.6.3"
 			}
 		},
 		"whatwg-mimetype": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-			"integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
 			"dev": true,
 			"requires": {
-				"tr46": "^3.0.0",
+				"tr46": "^5.1.0",
 				"webidl-conversions": "^7.0.0"
 			}
 		},
@@ -37576,9 +39423,9 @@
 			}
 		},
 		"which-typed-array": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
 			"dev": true,
 			"requires": {
 				"available-typed-arrays": "^1.0.7",
@@ -37702,9 +39549,9 @@
 			"dev": true
 		},
 		"xml-name-validator": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-			"integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
 			"dev": true
 		},
 		"xmlchars": {

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
 		"url": "https://github.com/colis/relicta"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "^30.27",
+		"@wordpress/scripts": "^31.5",
 		"husky": "^9.1.7",
-		"lint-staged": "^16.2.6",
+		"lint-staged": "^16.3.1",
 		"node-sass": "^9.0.0",
-		"sass-loader": "^16.0.6"
+		"sass-loader": "^16.0.7"
 	},
 	"engines": {
 		"node": ">=14.0.0"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -48,6 +48,7 @@
 	<exclude-pattern>/plugins/redirection/*</exclude-pattern>
 	<exclude-pattern>/plugins/wordpress-seo/*</exclude-pattern>
 	<exclude-pattern>/themes/twentytwentyfour/*</exclude-pattern>
+	<exclude-pattern>/themes/twentytwentyfive/*</exclude-pattern>
 
 	<!-- Other files and folders -->
 	<exclude-pattern>/*.asset.php</exclude-pattern>


### PR DESCRIPTION
This PR updates the following Composer dependencies
```
dealerdirect/phpcodesniffer-composer-installer 1.1.2               1.2.0 
wp-coding-standards/wpcs                       dev-develop b2e3d0f dev-develop c580c6c
wpackagist-plugin/aruba-hispeed-cache          3.0.1               3.0.6
wpackagist-plugin/cookie-law-info              3.3.6               3.4.0
wpackagist-plugin/imagify                      2.2.6               2.2.7
wpackagist-plugin/query-monitor                3.20.0              3.20.2
wpackagist-plugin/redirection                  5.5.2               5.7.5
wpackagist-plugin/wordpress-seo                26.3                27.0
```

and the following Node dependencies
```
@wordpress/scripts   ^30.27  →    ^31.5
lint-staged         ^16.2.6  →  ^16.3.1
sass-loader         ^16.0.6  →  ^16.0.7
```